### PR TITLE
Fix: Build Flash Attention v3 from source for Hopper images

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -66,11 +66,11 @@ RUN uv pip install --system packaging setuptools wheel psutil
 
 RUN echo "Processing Flash Attention installation..." && \
     if [ "$TORCH_CHANNEL" = "nightly" ]; then \
-        echo "Installing latest Flash-Attention v3 nightly (>=3,<4)"; \
-        ACTUAL_MAX_JOBS=${MAX_JOBS:-12} && \
-        echo "Using MAX_JOBS=${ACTUAL_MAX_JOBS}" && \
-        uv pip install --system --pre \
-            'flash-attn>=3,<4' --no-build-isolation; \
+        echo "Building Flash-Attention v3 from source for nightly PyTorch..." && \
+        git clone --depth 1 https://github.com/Dao-AILab/flash-attention.git /tmp/fa && \
+        cd /tmp/fa && \
+        MAX_JOBS=${MAX_JOBS:-6} uv pip install --system --no-build-isolation . && \
+        cd / && rm -rf /tmp/fa; \
     elif [ -n "$FA_VER" ]; then \
         echo "Installing Flash-Attention version $FA_VER"; \
         ACTUAL_MAX_JOBS=${MAX_JOBS:-12} && \


### PR DESCRIPTION
The Hopper (nightly PyTorch) Docker builds were failing because flash-attn versions >=3,<4 are not yet available as pre-built wheels on PyPI for the required Python 3.11 + CUDA 12.8 combination.

This change modifies the Dockerfile to compile Flash Attention v3 directly from the Dao-AILab/flash-attention GitHub repository when TORCH_CHANNEL is 'nightly'. This ensures that Hopper images can be built successfully with Flash Attention v3, enabling its performance benefits.

The MAX_JOBS variable is set to a default of 6 during this source compilation to prevent potential OOM issues, as recommended.

Builds for other architectures (Ampere, Turing) that use stable PyTorch and pre-built Flash Attention wheels (or skip it) are unaffected by this change.