### PR TITLE
Fix: Remove verbose argument from LRScheduler.__init__

### DIFF
--- a/linnaeus/lr_schedulers/schedulers/stable_decay_scheduler.py
+++ b/linnaeus/lr_schedulers/schedulers/stable_decay_scheduler.py
@@ -53,7 +53,7 @@ class StableDecayScheduler(_LRScheduler):
 
         # Initialize _LRScheduler. Note: self.base_lrs will be initially set
         # from the optimizer's current LR, but we'll overwrite them based on stable_lr.
-        super().__init__(optimizer, last_epoch=last_epoch, verbose=verbose)
+        super().__init__(optimizer, last_epoch=last_epoch)
 
         # Explicitly set base_lrs to the intended stable_lr for get_lr logic
         self.base_lrs = [self.stable_lr for _ in self.optimizer.param_groups]


### PR DESCRIPTION
This commit removes the `verbose` argument from the call to `super().__init__` in the `StableDecayScheduler` class to resolve the compatibility issue. The `verbose` attribute is still stored on the instance and can be used if needed for logging within the scheduler itself, but it's no longer passed to the parent class constructor.

(Yes this should have been on a feature branch)