### PR TITLE
Fix: Address critical bugs and update deprecated GradScaler

### DIFF
--- a/linnaeus/main.py
+++ b/linnaeus/main.py
@@ -970,7 +970,7 @@ def main(config, args=None):
         logger.debug(f"\n{schedule_text}")
 
     # AMP
-    scaler = GradScaler(enabled=(config.TRAIN.AMP_OPT_LEVEL != "O0"))
+    scaler = torch.amp.GradScaler('cuda', enabled=(config.TRAIN.AMP_OPT_LEVEL != "O0"))
 
     # Possibly do autobatch for training and validation now that optimizer,
     # loss functions, grad weighting, and scaler are available

--- a/linnaeus/models/blocks/rope_2d_mhsa.py
+++ b/linnaeus/models/blocks/rope_2d_mhsa.py
@@ -358,7 +358,7 @@ class RoPE2DAttention(nn.Module):
             # Needs coordinates for the current size
             t_x, t_y = init_t_xy(W, H, device=device)
             freqs_cis = compute_mixed_cis(self.freqs.to(device), t_x, t_y)  # Compute complex
-            return freqs_cis.to(self.freqs.dtype)  # Match learnable freqs dtype
+            return freqs_cis.to(torch.complex64)
         else:
             # Axial: Check if precomputed size matches
             if N_img != self.freqs_cis.shape[0]:

--- a/linnaeus/utils/schedule_utils.py
+++ b/linnaeus/utils/schedule_utils.py
@@ -912,8 +912,10 @@ def generate_schedule_plot(config: CN, schedule_summary: dict[str, Any], total_s
 
         meta_mask_prob = np.ones_like(steps) * end_prob
         if meta_end_steps > 0:
-            ramp_steps = np.minimum(steps, meta_end_steps)
-            meta_mask_prob[: meta_end_steps + 1] = start_prob + (end_prob - start_prob) * (ramp_steps / meta_end_steps)
+            # Create a ramp of the correct size, up to the end step
+            ramp_steps_correct = np.arange(min(meta_end_steps + 1, len(steps)))
+            # Apply the ramp calculation to the correct slice
+            meta_mask_prob[: len(ramp_steps_correct)] = start_prob + (end_prob - start_prob) * (ramp_steps_correct / meta_end_steps)
 
         (line_meta,) = ax.plot(steps, meta_mask_prob, "r-", linewidth=2.5)
         legend_entries.append((line_meta, "Full Meta-Masking Probability"))
@@ -956,8 +958,10 @@ def generate_schedule_plot(config: CN, schedule_summary: dict[str, Any], total_s
 
         null_mask_prob = np.ones_like(steps) * end_prob
         if null_end_steps > 0:
-            ramp_steps = np.minimum(steps, null_end_steps)
-            null_mask_prob[: null_end_steps + 1] = start_prob + (end_prob - start_prob) * (ramp_steps / null_end_steps)
+            # Create a ramp of the correct size, up to the end step
+            ramp_steps_correct = np.arange(min(null_end_steps + 1, len(steps)))
+            # Apply the ramp calculation to the correct slice
+            null_mask_prob[: len(ramp_steps_correct)] = start_prob + (end_prob - start_prob) * (ramp_steps_correct / null_end_steps)
 
         (line_null,) = ax.plot(steps, null_mask_prob, "b-", linewidth=2.5)
         legend_entries.append((line_null, "Null Masking Inclusion Probability"))
@@ -970,8 +974,10 @@ def generate_schedule_plot(config: CN, schedule_summary: dict[str, Any], total_s
 
         mix_prob = np.ones_like(steps) * end_prob
         if mix_end_steps > 0:
-            ramp_steps = np.minimum(steps, mix_end_steps)
-            mix_prob[: mix_end_steps + 1] = start_prob + (end_prob - start_prob) * (ramp_steps / mix_end_steps)
+            # Create a ramp of the correct size, up to the end step
+            ramp_steps_correct = np.arange(min(mix_end_steps + 1, len(steps)))
+            # Apply the ramp calculation to the correct slice
+            mix_prob[: len(ramp_steps_correct)] = start_prob + (end_prob - start_prob) * (ramp_steps_correct / mix_end_steps)
 
         (line_mix,) = ax.plot(steps, mix_prob, "m-", linewidth=2.5)
 


### PR DESCRIPTION
This commit addresses three issues:

1.  **Schedule Plot Failure:** Corrected a NumPy broadcasting error in `linnaeus/utils/schedule_utils.py` within the `generate_schedule_plot` function. The ramp calculations for `meta_mask_prob`, `null_mask_prob`, and `mix_prob` now use correctly sized arrays, preventing crashes during plot generation.

2.  **Casting Complex to Real in RoPE:** Fixed a bug in `linnaeus/models/blocks/rope_2d_mhsa.py` where the `_get_current_freqs_cis` function would cast complex-valued rotary position embeddings to real numbers, effectively discarding the imaginary part and neutralizing the positional encoding. The function now correctly returns a complex tensor (`torch.complex64`).

3.  **GradScaler Deprecation:** Updated `linnaeus/main.py` to use `torch.amp.GradScaler('cuda', ...)` instead of the deprecated `torch.cuda.amp.GradScaler(...)`.