### PR TITLE
Fix: Ensure proper rank synchronization after AutoBatch

### DIFF
--- a/docs/training/scheduling.md
+++ b/docs/training/scheduling.md
@@ -64,7 +64,7 @@ This schedule implements the Warmup-Stable-Decay pattern. It requires the standa
 **Note:** The sum of `STABLE_DURATION_FRACTION` and `DECAY_DURATION_FRACTION` does not need to be 1.0. After the decay phase completes, the LR remains at `MIN_LR`.
 
 -   **Initialization:** `total_steps` and `optimizer_steps_per_epoch` are calculated accurately in `main.py` after dataloader initialization. These values are used by `lr_schedulers.build.build_scheduler` to configure warmup steps and decay durations correctly.
--   **LR Scaling:** Applied automatically by `utils.schedule_utils.apply_lr_scaling` based on `effective_batch_size = per_gpu_batch_size * world_size * accumulation_steps`.
+-   **LR Scaling:** Applied automatically by `utils.schedule_utils.apply_lr_scaling` based on `effective_batch_size = per_gpu_batch_size * world_size * accumulation_steps`. Note: This scaling mechanism modifies the initial learning rates in the optimizer. It assumes that the chosen learning rate scheduler uses these initial values as its starting point, which is standard for most schedulers.
 -   **Parameter Groups:** Supports different LR schedules per parameter group via `LR_SCHEDULER.PARAMETER_GROUPS`. See `configs/` for examples.
 
 ### Validation Scheduling (`SCHEDULE.VALIDATION`)

--- a/linnaeus/main.py
+++ b/linnaeus/main.py
@@ -710,28 +710,6 @@ def main(config, args=None):
             logger.debug("Added step_update shim to LR scheduler.")
     logger.info("LR scheduler built.")
 
-    # Apply LR Scaling
-    from linnaeus.utils.schedule_utils import apply_lr_scaling
-
-    # Get distributed info safely
-    is_distributed = dist.is_available() and dist.is_initialized()
-    world_size = dist.get_world_size() if is_distributed else 1
-    rank = dist.get_rank() if is_distributed else 0
-    # Calculate effective batch size
-    effective_batch_size_for_scaling = config.DATA.BATCH_SIZE * world_size * accumulation_steps
-    # Pass effective size and logging components to the modified apply_lr_scaling
-    per_gpu_bs = config.DATA.BATCH_SIZE  # For logging string only
-    _ = apply_lr_scaling(
-        config,
-        optimizer,
-        effective_batch_size=effective_batch_size_for_scaling,
-        rank=rank,
-        per_gpu_bs_for_log=per_gpu_bs,
-        world_size_for_log=world_size,
-        accum_steps_for_log=accumulation_steps,
-    )
-    logger.info("LR scaling applied.")
-
     # ---> START REVISED DDP WRAPPING SECTION (Force True for GradNorm) <---
     if dist.is_available() and dist.is_initialized():
         # Determine the final value for find_unused_parameters
@@ -1034,6 +1012,11 @@ def main(config, args=None):
         if rank == 0:
             logger.info(f"[Autobatch] Using val BATCH_SIZE_VAL={best_val_bs}")
 
+    # Synchronize after all ranks have potentially updated their config from autobatch search
+    if dist.is_available() and dist.is_initialized():
+        logger.info("[Autobatch] Synchronizing all ranks after batch size determination and before loader rebuild.")
+        dist.barrier()
+
     # If autobatch was used, we need to rebuild the data loaders with the new batch sizes
     if config.DATA.AUTOBATCH.ENABLED or config.DATA.AUTOBATCH.ENABLED_VAL:
         logger.info("[Autobatch] Rebuilding data loaders with updated batch sizes...")
@@ -1080,18 +1063,38 @@ def main(config, args=None):
         logger.info(f"  Optimizer steps per epoch: {optimizer_steps_per_epoch}")
         logger.info(f"  Total training steps: {total_steps}")
 
-        # Re-save the config files with updated batch sizes
-        if rank == 0:
-            model_cfg_path = os.path.join(config.ENV.OUTPUT.DIRS.CONFIGS, "model_config.yaml")
+    # Apply LR Scaling (moved here, after autobatch and total_steps recalculation)
+    from linnaeus.utils.schedule_utils import apply_lr_scaling
+
+    # Get distributed info safely
+    is_distributed = dist.is_available() and dist.is_initialized()
+    world_size = dist.get_world_size() if is_distributed else 1
+    rank = dist.get_rank() if is_distributed else 0 # rank is defined earlier, but good to have it close
+    # Calculate effective batch size using the potentially updated config.DATA.BATCH_SIZE
+    # accumulation_steps is defined earlier and should be in scope
+    effective_batch_size_for_scaling = config.DATA.BATCH_SIZE * world_size * accumulation_steps
+    # Pass effective size and logging components to the modified apply_lr_scaling
+    per_gpu_bs = config.DATA.BATCH_SIZE  # For logging string only, using the updated batch size
+    _ = apply_lr_scaling(
+        config,
+        optimizer,
+        effective_batch_size=effective_batch_size_for_scaling,
+        rank=rank,
+        per_gpu_bs_for_log=per_gpu_bs,
+        world_size_for_log=world_size,
+        accum_steps_for_log=accumulation_steps,
+    )
+    logger.info("LR scaling applied (after autobatch).")
+
+    # Re-save the config files with updated batch sizes (if autobatch ran)
+    if (config.DATA.AUTOBATCH.ENABLED or config.DATA.AUTOBATCH.ENABLED_VAL) and rank == 0:
+        model_cfg_path = os.path.join(config.ENV.OUTPUT.DIRS.CONFIGS, "model_config.yaml")
             save_config(config, model_cfg_path)
-            logger.info(f"[Autobatch] Updated model config => {model_cfg_path}")
+            logger.info(f"[Autobatch] Updated model config with new BATCH_SIZE => {model_cfg_path}")
 
             exp_cfg_path = os.path.join(config.ENV.OUTPUT.DIRS.CONFIGS, "experiment_config.yaml")
             save_config(config, exp_cfg_path)
-            logger.info(f"[Autobatch] Updated experiment config => {exp_cfg_path}")
-
-    if dist.is_initialized():
-        dist.barrier()
+            logger.info(f"[Autobatch] Updated experiment config with new BATCH_SIZE => {exp_cfg_path}")
 
     # Logging
     if rank == 0:


### PR DESCRIPTION
The previous commit correctly moved LR scaling to after AutoBatch but revealed a synchronization issue where non-rank-0 processes could proceed to rebuild data loaders and perform other operations with stale batch size information before rank 0 finished AutoBatch and broadcasted the new batch sizes. This could lead to hangs or errors in distributed training.

This commit addresses the regression by:
1.  Moving the `dist.barrier()` in `linnaeus/main.py` to an earlier position. The barrier is now placed immediately after both the training and validation batch sizes have been determined by `auto_find_batch_size` (which handles its own rank 0 search and broadcast) and updated in the configuration on all ranks.
2.  This new barrier placement ensures that all ranks are synchronized with the correct batch sizes *before* they proceed to rebuild data loaders, recalculate `optimizer_steps_per_epoch` / `total_steps`, or apply learning rate scaling.

The `linnaeus/utils/autobatch.py` file itself was found to have correct rank guarding for its search and broadcast operations, so no changes were made there. The issue was purely in the coordination of ranks within `main.py`.