### PR TITLE
[docker] pre-install rclone and debug tools

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -35,6 +35,10 @@ RUN apt-get update || (sleep 10 && apt-get update) || (sleep 20 && apt-get updat
     libfontconfig1 \
     libxrender1 \
     libgl1-mesa-glx \
+    htop \
+    nvtop \
+    nano \
+    && curl -fsSL https://rclone.org/install.sh | sh \
     && rm -rf /var/lib/apt/lists/*
 
 # Link python3 to python3.11 and create python symlink


### PR DESCRIPTION
## Summary
- add rclone install script to base stage
- include htop, nvtop, and nano for easier debugging

## Testing
- `ruff format .`
- `ruff check --fix --exit-zero .`
- `ruff check --exit-zero .`

------
https://chatgpt.com/codex/tasks/task_e_68532a5db960832ea3718080dd9eabbc