### PR TITLE
Refactor(optimizers): Improve MultiOptimizer checkpoint logging for LOG-102

### DIFF
--- a/linnaeus/lr_schedulers/tests/test_wsd_scheduler.py
+++ b/linnaeus/lr_schedulers/tests/test_wsd_scheduler.py
@@ -1,12 +1,13 @@
 import unittest
+from unittest.mock import MagicMock
+
 import torch
 from torch.optim import SGD
-from unittest.mock import MagicMock
 
 # Assuming the schedulers are importable like this. Adjust if necessary.
 from linnaeus.lr_schedulers.schedulers.stable_decay_scheduler import StableDecayScheduler
 from linnaeus.lr_schedulers.schedulers.warmup_lr_scheduler import WarmupLRScheduler
-from linnaeus.utils.logging.logger import get_main_logger # For logger access if needed
+
 
 # Basic model and optimizer for testing
 class DummyModel(torch.nn.Module):
@@ -17,8 +18,8 @@ class DummyModel(torch.nn.Module):
     def forward(self, x):
         return self.param * x
 
-class TestWSDScheduler(unittest.TestCase):
 
+class TestWSDScheduler(unittest.TestCase):
     def setUp(self):
         self.model = DummyModel()
         self.initial_lr = 0.1
@@ -33,7 +34,7 @@ class TestWSDScheduler(unittest.TestCase):
                 decay_steps=100,
                 stable_lr=0.05,
                 min_lr=0.001,
-                verbose=False # Test with False
+                verbose=False,  # Test with False
             )
             self.assertIsNotNone(scheduler)
             scheduler = StableDecayScheduler(
@@ -42,7 +43,7 @@ class TestWSDScheduler(unittest.TestCase):
                 decay_steps=100,
                 stable_lr=0.05,
                 min_lr=0.001,
-                verbose=True # Test with True
+                verbose=True,  # Test with True
             )
             self.assertIsNotNone(scheduler)
         except TypeError as e:
@@ -54,7 +55,7 @@ class TestWSDScheduler(unittest.TestCase):
         """Test correct step counting and LR during stable phase (Fixes Issue 2)."""
         warmup_steps = 50
         warmup_lr_init = 0.01
-        stable_lr_sds = 0.05 # Target LR for stable phase in SDS
+        stable_lr_sds = 0.05  # Target LR for stable phase in SDS
         min_lr_sds = 0.001
         stable_steps_sds = 100
         decay_steps_sds = 100
@@ -65,7 +66,7 @@ class TestWSDScheduler(unittest.TestCase):
             decay_steps=decay_steps_sds,
             stable_lr=stable_lr_sds,
             min_lr=min_lr_sds,
-            verbose=False # Verbosity for SDS itself
+            verbose=False,  # Verbosity for SDS itself
         )
 
         # Mock WarmupLRScheduler's logger to check verbosity later if needed
@@ -73,45 +74,46 @@ class TestWSDScheduler(unittest.TestCase):
         # WarmupLRScheduler.logger = MagicMock() # Example if we wanted to mock its logger
 
         wlr_scheduler = WarmupLRScheduler(
-            optimizer=self.optimizer,
-            warmup_steps=warmup_steps,
-            warmup_lr_init=warmup_lr_init,
-            base_scheduler=sds
+            optimizer=self.optimizer, warmup_steps=warmup_steps, warmup_lr_init=warmup_lr_init, base_scheduler=sds
         )
 
         # Simulate steps
         # Phase 1: Warmup
         for i in range(warmup_steps):
             wlr_scheduler.step_update(i)
-            current_lr = self.optimizer.param_groups[0]['lr']
+            current_lr = self.optimizer.param_groups[0]["lr"]
             expected_lr = warmup_lr_init + (stable_lr_sds - warmup_lr_init) * (i / warmup_steps)
             self.assertAlmostEqual(current_lr, expected_lr, places=6, msg=f"Warmup LR mismatch at step {i}")
 
         # Phase 2: Transition to StableDecayScheduler's stable phase
         # At this point, WarmupLRScheduler should pass step 0 to StableDecayScheduler
         # Test a few steps into the stable phase
-        for i in range(5): # Test 5 steps into stable phase
+        for i in range(5):  # Test 5 steps into stable phase
             global_step = warmup_steps + i
             wlr_scheduler.step_update(global_step)
-            current_lr = self.optimizer.param_groups[0]['lr']
+            current_lr = self.optimizer.param_groups[0]["lr"]
             # SDS's get_lr() uses self.last_epoch + 1.
             # If step_update(0) was called, last_epoch becomes 0, so get_lr uses step 1.
             # The LR should be stable_lr_sds
-            self.assertAlmostEqual(current_lr, stable_lr_sds, places=6,
-                                   msg=f"Stable phase LR mismatch at global_step {global_step} (SDS step {i})")
+            self.assertAlmostEqual(
+                current_lr, stable_lr_sds, places=6, msg=f"Stable phase LR mismatch at global_step {global_step} (SDS step {i})"
+            )
 
         # Check SDS internal state (optional, but good for debugging)
-        self.assertEqual(sds.last_epoch, 4) # After 5 steps (0 to 4) passed to SDS
+        self.assertEqual(sds.last_epoch, 4)  # After 5 steps (0 to 4) passed to SDS
 
         # Phase 3: Further into stable phase
-        stable_phase_step_10 = 10 # 10th step *within* SDS's stable phase
+        stable_phase_step_10 = 10  # 10th step *within* SDS's stable phase
         global_step_stable_10 = warmup_steps + stable_phase_step_10
         wlr_scheduler.step_update(global_step_stable_10)
-        current_lr = self.optimizer.param_groups[0]['lr']
-        self.assertAlmostEqual(current_lr, stable_lr_sds, places=6,
-                               msg=f"Stable phase LR mismatch at global_step {global_step_stable_10} (SDS step {stable_phase_step_10})")
+        current_lr = self.optimizer.param_groups[0]["lr"]
+        self.assertAlmostEqual(
+            current_lr,
+            stable_lr_sds,
+            places=6,
+            msg=f"Stable phase LR mismatch at global_step {global_step_stable_10} (SDS step {stable_phase_step_10})",
+        )
         self.assertEqual(sds.last_epoch, stable_phase_step_10)
-
 
     def test_03_logging_verbosity(self):
         """Test that StableDecayScheduler does not log when managed by WarmupLRScheduler if WarmupLRScheduler handles logging."""
@@ -134,26 +136,20 @@ class TestWSDScheduler(unittest.TestCase):
             decay_steps=20,
             stable_lr=stable_lr_sds,
             min_lr=0.001,
-            verbose=True # SDS verbose is true
+            verbose=True,  # SDS verbose is true
         )
-        sds.print_lr = MagicMock() # Mock its print_lr specifically
+        sds.print_lr = MagicMock()  # Mock its print_lr specifically
 
-        wlr_scheduler = WarmupLRScheduler(
-            optimizer=self.optimizer,
-            warmup_steps=warmup_steps,
-            warmup_lr_init=0.01,
-            base_scheduler=sds
-        )
+        wlr_scheduler = WarmupLRScheduler(optimizer=self.optimizer, warmup_steps=warmup_steps, warmup_lr_init=0.01, base_scheduler=sds)
 
         # Simulate steps past warmup
-        for i in range(warmup_steps + 5): # Go 5 steps into SDS phase
+        for i in range(warmup_steps + 5):  # Go 5 steps into SDS phase
             # We need to ensure WarmupLRScheduler's own logging is also handled.
             # The ticket implies WarmupLRScheduler is the source of truth for logging.
             # For this test, we're primarily concerned that SDS.print_lr isn't the one firing.
             # We can simulate the config for WarmupLRScheduler's logger:
-            if not hasattr(self.optimizer.param_groups[0], 'config'):
-                 self.optimizer.param_groups[0]['config'] = {'DEBUG': {'SCHEDULING': True}}
-
+            if not hasattr(self.optimizer.param_groups[0], "config"):
+                self.optimizer.param_groups[0]["config"] = {"DEBUG": {"SCHEDULING": True}}
 
             wlr_scheduler.step_update(i)
 
@@ -167,5 +163,6 @@ class TestWSDScheduler(unittest.TestCase):
         # This part is more involved and depends on how WarmupLRScheduler's logger is accessed.
         # The critical part of the ticket (removing SDS.print_lr) is covered by it not being called.
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/linnaeus/optimizers/multi_optimizer.py
+++ b/linnaeus/optimizers/multi_optimizer.py
@@ -17,6 +17,7 @@ import torch
 from torch.optim import Optimizer
 
 from linnaeus.utils.debug_utils import check_debug_flag
+from linnaeus.utils.distributed import get_rank_safely
 from linnaeus.utils.logging.logger import get_main_logger
 
 logger = get_main_logger()
@@ -169,6 +170,7 @@ class MultiOptimizer:
             opt_state_dict = {"state": {}, "param_groups": saved_opt_state["param_groups"]}
 
             # Remap stable indices back to current parameter IDs
+            missing_indices = []
             for stable_idx, param_state in saved_opt_state["state"].items():
                 # Convert to int if string (for JSON compatibility)
                 stable_idx = int(stable_idx)
@@ -184,7 +186,21 @@ class MultiOptimizer:
                                 f"exp_avg shape = {param_state['exp_avg'].shape}"
                             )
                 else:
-                    logger.warning(f"Stable index {stable_idx} not found in current parameters")
+                    missing_indices.append(stable_idx)
+
+            # Log missing indices if any
+            if get_rank_safely() == 0 and missing_indices:
+                # 1. Log the summary warning
+                logger.warning(
+                    f"[MultiOptimizer] {len(missing_indices)} parameters from checkpoint state were not found "
+                    "in the current model's parameters and will be ignored."
+                )
+
+                # 2. Log the detailed list only if the debug flag is set
+                if check_debug_flag(self.config, "DEBUG.CHECKPOINT"):
+                    logger.debug("[MultiOptimizer] List of missing parameter indices from checkpoint:")
+                    for idx in sorted(missing_indices):  # Sorting is good for consistency
+                        logger.debug(f"  - Parameter with stable index {idx} not found in current model.")
 
             # Load the remapped state
             opt.load_state_dict(opt_state_dict)


### PR DESCRIPTION
Reduces log noise from MultiOptimizer during checkpoint loading.
- A single summary warning is now logged on rank 0 if parameters from the checkpoint state are not found in the current model's parameters.
- Detailed lists of missing parameter indices are only logged if the DEBUG.CHECKPOINT flag is true, also restricted to rank 0.
- All related logging is now gated to execute only on rank 0.

These changes address issue LOG-102 by making checkpoint loading logs less verbose during normal runs while retaining detailed information for debugging purposes.

TODO: Needs testing + verification (tabled for full Jun19_0.0.22 verification run before merge into main).