### PR TITLE
Fix: Add monitor_interval/enabled args to dataset constructors and base class (Jules)

### DIFF
--- a/linnaeus/h5data/base_prefetching_dataset.py
+++ b/linnaeus/h5data/base_prefetching_dataset.py
@@ -94,6 +94,8 @@ class BasePrefetchingDataset(ABC):
         augmentation_pipeline: Any,
         simulate_hpc: bool,
         io_delay: float,
+        monitor_interval: float = 10.0,  # Default interval in seconds
+        monitor_enabled: bool = True,  # Default to enabled
         main_logger=None,
         h5data_logger=None,
     ):
@@ -122,6 +124,8 @@ class BasePrefetchingDataset(ABC):
         self.sleep_time = sleep_time
         self.simulate_hpc = simulate_hpc
         self.io_delay = io_delay
+        self.monitor_interval = monitor_interval
+        self.monitor_enabled = monitor_enabled
         self.main_logger = main_logger or get_h5data_logger()
         self.h5data_logger = h5data_logger or logging.getLogger("h5data")
 
@@ -143,6 +147,7 @@ class BasePrefetchingDataset(ABC):
         self._batch_feeder_thread = None  # ephemeral each epoch
         self._prefetch_manager_thread = None
         self._preprocess_manager_thread = None
+        self._monitor_thread = None
 
         self._io_threadpool = None
         self._transform_threadpool = ThreadPoolExecutor(max_workers=self.num_preprocess_threads)
@@ -176,7 +181,8 @@ class BasePrefetchingDataset(ABC):
         self.main_logger.info(
             f"[BasePrefetchingDataset] init => concurrency={batch_concurrency}, "
             f"max_processed={max_processed_batches}, IO threads={num_io_threads}, "
-            f"Preproc threads={num_preprocess_threads}, HPC={simulate_hpc}"
+            f"Preproc threads={num_preprocess_threads}, HPC={simulate_hpc}, "
+            f"MonitorEnabled={self.monitor_enabled}, MonitorInterval={self.monitor_interval}"
         )
 
     # ------------------------------------------------------------------------
@@ -332,15 +338,22 @@ class BasePrefetchingDataset(ABC):
             self.main_logger.debug(f"[{class_name}] Joining prefetch manager thread...")
             self._prefetch_manager_thread.join(timeout=thread_timeout)
             if self._prefetch_manager_thread.is_alive():
-                self.main_logger.warning(f"[{class_name}] Prefetch manager thread timed out.")
+                self.main_logger.warning(f"[{class_name}] Prefetch manager thread timed out on join.")
         self._prefetch_manager_thread = None
 
         if self._preprocess_manager_thread and self._preprocess_manager_thread.is_alive():
             self.main_logger.debug(f"[{class_name}] Joining preprocess manager thread...")
             self._preprocess_manager_thread.join(timeout=thread_timeout)
             if self._preprocess_manager_thread.is_alive():
-                self.main_logger.warning(f"[{class_name}] Preprocess manager thread timed out.")
+                self.main_logger.warning(f"[{class_name}] Preprocess manager thread timed out on join.")
         self._preprocess_manager_thread = None
+
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            self.main_logger.debug(f"[{class_name}] Joining monitor thread...")
+            self._monitor_thread.join(timeout=thread_timeout)
+            if self._monitor_thread.is_alive():
+                self.main_logger.warning(f"[{class_name}] Monitor thread timed out on join.")
+        self._monitor_thread = None
 
         # Shutdown thread pools
         if self._io_threadpool:
@@ -370,6 +383,7 @@ class BasePrefetchingDataset(ABC):
         Spawns the background concurrency threads that run for the dataset's entire lifetime:
           1) _prefetch_manager_thread
           2) _preprocess_manager_thread
+          3) _monitor_thread (if enabled)
         """
         if self._prefetch_manager_thread is None or not self._prefetch_manager_thread.is_alive():
             self._prefetch_manager_thread = threading.Thread(
@@ -382,6 +396,66 @@ class BasePrefetchingDataset(ABC):
                 target=self._preprocess_main_loop, daemon=True, name=f"{self.__class__.__name__}_PreprocessManagerThread"
             )
             self._preprocess_manager_thread.start()
+
+        if self.monitor_enabled and (self._monitor_thread is None or not self._monitor_thread.is_alive()):
+            self._monitor_thread = threading.Thread(
+                target=self._monitor_loop, daemon=True, name=f"{self.__class__.__name__}_MonitorThread"
+            )
+            self._monitor_thread.start()
+
+    def _monitor_loop(self):
+        """Periodically logs queue sizes and other metrics."""
+        class_name = self.__class__.__name__
+        self.main_logger.info(f"[{class_name}] Monitor thread started. Logging interval: {self.monitor_interval}s.")
+        try:
+            while not self._shutdown_event.wait(self.monitor_interval): # Wait for interval or shutdown
+                if self._shutdown_event.is_set():
+                    break
+
+                # Log queue sizes
+                batch_idx_q_size = self._batch_index_queue.qsize()
+                preprocess_q_size = self._preprocess_queue.qsize()
+                processed_batch_q_size = self._processed_batch_queue.qsize()
+
+                self.metrics["queue_depths"]["batch_index_q"].append(batch_idx_q_size)
+                self.metrics["queue_depths"]["preprocess_q"].append(preprocess_q_size)
+                self.metrics["queue_depths"]["processed_batch_q"].append(processed_batch_q_size)
+
+                # Log cache metrics
+                cache_stats = self.prefetch_cache.get_stats()
+                self.metrics["cache_metrics"]["size"].append(cache_stats["size"])
+                self.metrics["cache_metrics"]["hits"] = cache_stats["hits"]
+                self.metrics["cache_metrics"]["misses"] = cache_stats["misses"]
+                self.metrics["cache_metrics"]["evictions"] = cache_stats["evictions"]
+                self.metrics["cache_metrics"]["memory_usage_bytes"] = cache_stats["memory_usage_bytes"]
+
+                # Calculate throughput (simple version: items per interval)
+                # More sophisticated throughput might require tracking items over time differently
+                current_time = time.time()
+                elapsed_time = current_time - self.start_time
+
+                if elapsed_time > 0:
+                    prefetch_throughput = self.prefetch_count / elapsed_time
+                    preprocess_throughput = self.preprocess_count / elapsed_time
+                    self.metrics["throughput"]["prefetch"].append(prefetch_throughput)
+                    self.metrics["throughput"]["preprocess"].append(preprocess_throughput)
+                else:
+                    prefetch_throughput = 0
+                    preprocess_throughput = 0
+
+                log_msg = (
+                    f"[{class_name}] Monitor: "
+                    f"BatchIdxQ={batch_idx_q_size}, PreprocQ={preprocess_q_size}, ProcessedQ={processed_batch_q_size} | "
+                    f"CacheSize={cache_stats['size']}, Hits={cache_stats['hits']}, Misses={cache_stats['misses']}, Evictions={cache_stats['evictions']}, MemUsage={cache_stats['memory_usage_bytes'] / (1024*1024):.2f}MB | "
+                    f"PrefetchThrpt={prefetch_throughput:.2f} items/s, PreprocThrpt={preprocess_throughput:.2f} items/s"
+                )
+                self.main_logger.info(log_msg)
+
+        except Exception as e:
+            self.main_logger.error(f"[{class_name}] Error in monitor loop: {e}", exc_info=True)
+        finally:
+            self.main_logger.info(f"[{class_name}] Monitor thread exited.")
+
 
     def _prefetch_manager_loop(self):
         """

--- a/linnaeus/h5data/build.py
+++ b/linnaeus/h5data/build.py
@@ -1065,6 +1065,8 @@ def _init_dataset(
     aug_pipeline: Any,
     class_to_idx: dict[str, dict[Any, int]],
     config: CN,
+    monitor_interval: float = 10.0,  # Default value
+    monitor_enabled: bool = True,  # Default value
 ) -> Any:
     """
     Create either a PrefetchingH5Dataset or a PrefetchingHybridDataset, attaching the entire
@@ -1100,6 +1102,30 @@ def _init_dataset(
     num_preprocess_threads = config.DATA.PREFETCH.NUM_PREPROCESS_THREADS
     sleep_time = config.DATA.PREFETCH.SLEEP_TIME
 
+    # Monitoring parameters from config, with defaults
+    cfg_monitor_interval = getattr(config.DATA.PREFETCH, "MONITOR_INTERVAL", 10.0)
+    cfg_monitor_enabled = getattr(config.DATA.PREFETCH, "MONITOR_ENABLED", True)
+
+    # Use parameters passed to function if they are not the default, otherwise use config values
+    # This allows overriding via direct call if necessary, but typically relies on config.
+    final_monitor_interval = monitor_interval if monitor_interval != 10.0 else cfg_monitor_interval
+    # Corrected logic for final_monitor_enabled:
+    # If monitor_enabled (function arg) is False (i.e., different from its default True), use the function arg.
+    # Otherwise (if it's True or any other non-False value), use the config value (cfg_monitor_enabled).
+    if monitor_enabled is False:
+        final_monitor_enabled = False
+    else:
+        final_monitor_enabled = cfg_monitor_enabled
+
+    if final_monitor_interval == 10.0 and cfg_monitor_interval == 10.0: # Default was used and config did not specify
+        main_logger.info("Using default monitor_interval (10.0) as it's not specified in DATA.PREFETCH.MONITOR_INTERVAL.")
+
+    # Log if the default for monitor_enabled is being used because it's not in config
+    # This occurs if final_monitor_enabled is True AND the original cfg_monitor_enabled was its default (True)
+    # AND MONITOR_ENABLED was not actually in DATA.PREFETCH
+    if final_monitor_enabled and cfg_monitor_enabled and not hasattr(config.DATA.PREFETCH, "MONITOR_ENABLED"):
+        main_logger.info("Using default monitor_enabled (True) as it's not specified in DATA.PREFETCH.MONITOR_ENABLED.")
+
     final_aug = aug_pipeline if not is_val else None
 
     # Decide Hybrid vs HDF5.
@@ -1125,6 +1151,8 @@ def _init_dataset(
             file_extension=config.DATA.HYBRID.FILE_EXTENSION,
             simulate_hpc=simulate_hpc_flag,
             io_delay=io_delay_val,
+            monitor_interval=final_monitor_interval,
+            monitor_enabled=final_monitor_enabled,
             config=config,
             main_logger=main_logger,
             h5data_logger=logging.getLogger("h5data"),
@@ -1148,6 +1176,8 @@ def _init_dataset(
             target_img_size=config.DATA.IMG_SIZE,
             simulate_hpc=simulate_hpc_flag,
             io_delay=io_delay_val,
+            monitor_interval=final_monitor_interval,
+            monitor_enabled=final_monitor_enabled,
             config=config,
             main_logger=main_logger,
             h5data_logger=logging.getLogger("h5data"),


### PR DESCRIPTION

- Added `monitor_interval` and `monitor_enabled` parameters to `PrefetchingHybridDataset` and `PrefetchingH5Dataset` constructors where they were missing during instantiation in `linnaeus.h5data.build._init_dataset`.
- Modified `BasePrefetchingDataset.__init__` to accept these new parameters and store them.
- Implemented a basic monitoring loop in `BasePrefetchingDataset` to log queue sizes, cache statistics, and throughput if `monitor_enabled` is True.
- Ensured monitor thread is properly started and stopped with other pipeline threads.
- Corrected boolean comparisons identified by ruff linter.