### PR TITLE
Docs: finalise slim-base / runtime build flow (0.1.1)

### DIFF
--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
         with:
+          # Reserve 3GB for BuildKit to prevent aggressive garbage collection
+          # This ensures GitHub's 14GB runners have ~11GB usable space
           driver-opts: |
             env.BUILDKIT_GC_KEEP_STORAGE=3g
       - uses: docker/login-action@v3
@@ -44,6 +46,8 @@ jobs:
         with:
           context: .
           file: tools/docker/Dockerfile.runtime
+          # IMPORTANT: Must match the stage name in Dockerfile.runtime (FROM ... AS runtime)
+          # This prevents BuildKit from evaluating unused stages that would exceed disk limits
           target: runtime
           platforms: linux/amd64
           build-args: |
@@ -55,6 +59,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
       
       - name: Check BuildKit tmp size
+        # Monitors BuildKit's temporary storage to ensure we stay within GitHub's disk limits
+        # We measure BuildKit's tmp dir (not /) for accurate usage after the slim base design
         run: |
           # Get BuildKit's tmp directory and measure its size
           buildkit_dir=$(docker buildx du 2>/dev/null | awk '/buildkit/{print $2}' | head -1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.1.1] - 2025-07-07
+
+### Added
+- Slim Docker base images (<8GB) enabling CI/CD on free GitHub runners
+- Multi-stage Docker build architecture separating builder and runtime stages
+- BuildKit disk usage monitoring in CI workflow
+- Comprehensive CI & Docker documentation
+- Inline documentation for critical workflow settings
+
+### Changed
+- Base Docker images now use `cuda-runtime` instead of `cuda-devel` (70% size reduction)
+- Runtime Docker builds complete in <2 minutes (previously 15-20 minutes)
+- Switched to proper semver format for pre-releases (v0.1.1-rc6 vs v0.1.1rc6)
+- Enhanced Docker README with architecture decision log and troubleshooting guide
+
+### Fixed
+- CI disk space errors on GitHub Actions runners
+- BuildKit evaluating unused Docker stages during runtime builds
+- Module-level logger initialization race conditions
+- Mixup/CutMix initialization timing issues in data loader
+
 ## 2025-05-28
 
 ### Added

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,166 @@
+# CI & Docker Guide
+
+This guide covers Linnaeus's continuous integration setup and Docker image architecture.
+
+## Overview
+
+Linnaeus CI uses a slim Docker workflow designed to run on GitHub's free runners (14GB disk limit). The system splits heavy dependencies (CUDA, PyTorch) into pre-built base images, allowing runtime builds to complete in under 2 minutes using less than 10GB of disk space.
+
+## Docker Image Architecture
+
+| Image | Purpose | Typical Size | Tag Example |
+|-------|---------|--------------|-------------|
+| `frontierkodiak/linnaeus-base` | Heavy CUDA/DL dependencies | 6-7GB | `turing-cu126` |
+| `frontierkodiak/linnaeus-dev` | Linnaeus runtime layer | 300MB layer | `turing-v0.1.1` |
+
+**Note:** End users typically only need the runtime images. Base images exist purely for CI caching.
+
+## Runtime Images on Free Runners
+
+### GitHub Runner Constraints
+- **Total disk space:** 14GB
+- **BuildKit reserve:** 3GB (configured in workflow)
+- **Available for builds:** ~11GB
+- **Our peak usage:** 8-10GB
+
+### How It Works
+
+1. **Base images** (<8GB) contain PyTorch, CUDA runtime, and all heavy dependencies
+2. **Runtime builds** pull the base and add only Linnaeus code (~300MB)
+3. **Disk guard** monitors BuildKit tmp usage to ensure we stay under 12GB
+
+### Workflow Configuration
+
+The runtime build workflow ([`.github/workflows/build-runtime.yml`](../.github/workflows/build-runtime.yml)) includes several critical settings:
+
+```yaml
+# Reserve disk space for BuildKit
+driver-opts: |
+  env.BUILDKIT_GC_KEEP_STORAGE=3g
+
+# Target specific Docker stage to skip heavy builder
+target: runtime
+
+# Monitor disk usage after build
+- name: Check BuildKit tmp size
+```
+
+## Adding New Dependencies
+
+When adding a new Python dependency:
+
+1. **Update `pyproject.toml`** with the new dependency
+2. **Update `Dockerfile.base`** - add the same dependency to the heavy dependencies RUN command:
+   ```dockerfile
+   RUN uv pip install \
+       numpy>=1.20 \
+       pandas \
+       your-new-package \  # Add here
+       ...
+   ```
+3. **Rebuild base images** for all architectures
+4. **Push updated base images** to Docker Hub
+5. **Update workflow matrix** if base image tags changed
+
+⚠️ **Important:** The runtime Dockerfile uses `--no-deps` to avoid downloading packages in CI. All dependencies MUST be in the base image.
+
+## Rebuilding Base Images
+
+### When to Rebuild
+- PyTorch version updates
+- CUDA version changes
+- New Python dependencies added
+- Flash Attention updates
+
+### Build Commands
+
+Base images use a multi-stage build that compiles in a 40GB `builder` stage but publishes only the slim `base` stage:
+
+```bash
+# Example for Ampere GPUs
+docker buildx build \
+  --platform linux/amd64 \
+  -f tools/docker/Dockerfile.base \
+  --target base \
+  --build-arg MAX_JOBS=4 \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg TORCH_CHANNEL=stable \
+  --build-arg TORCH_VER=2.7.1+cu126 \
+  --build-arg TORCH_CUDA_SUFFIX=cu126 \
+  --build-arg CUDA_ARCH_LIST="8.0;8.6" \
+  --build-arg FA_VER=2.7.4.post1 \
+  -t frontierkodiak/linnaeus-base:ampere-cu126 \
+  --push .
+```
+
+See the [Docker build guide](../tools/docker/README.md) for complete build commands for all architectures.
+
+### Updating the Workflow
+
+After pushing new base images, update the matrix in `.github/workflows/build-runtime.yml`:
+
+```yaml
+matrix:
+  include:
+    - arch: turing
+      base_tag: turing-cu126  # Update this tag
+    - arch: ampere
+      base_tag: ampere-cu126  # Update this tag
+    - arch: hopper
+      base_tag: hopper-cu128-nightly  # Update this tag
+```
+
+## Tagging and Releases
+
+### Version Format
+- **Stable releases:** `vX.Y.Z` (e.g., `v0.1.1`)
+- **Pre-releases:** `vX.Y.Z-rcN` with hyphen (e.g., `v0.1.1-rc7`)
+
+### Release Process
+1. Update version in `pyproject.toml`
+2. Commit changes to main branch
+3. Create and push tag:
+   ```bash
+   git tag -a v0.1.1 -m "Release v0.1.1"
+   git push origin v0.1.1
+   ```
+4. GitHub Actions automatically builds and pushes runtime images
+
+## Monitoring Builds
+
+### Build Logs
+Check the Actions tab on GitHub for:
+- Build duration (should be <2 minutes)
+- Disk usage report (should show <10GB)
+- Image push confirmation
+
+### Common Issues
+
+**"target stage runtime could not be found"**
+- Ensure `Dockerfile.runtime` has `FROM ... AS runtime`
+
+**Disk space errors**
+- Verify base images are <8GB
+- Check `target: runtime` is set in workflow
+- Ensure `BUILDKIT_GC_KEEP_STORAGE=3g` is configured
+
+**Missing dependencies**
+- Add to both `pyproject.toml` AND `Dockerfile.base`
+- Rebuild and push base images
+
+## Technical Notes
+
+### Why This Architecture?
+
+1. **Size constraints:** Original monolithic images were 19-22GB, exceeding runner capacity
+2. **Build time:** Compiling Flash Attention takes 15-20 minutes
+3. **Solution:** Pre-build heavy layers, CI only adds application code
+
+### MAX_JOBS Parameter
+
+The `MAX_JOBS` build argument only affects base image builds (Flash Attention compilation):
+- High memory systems: `MAX_JOBS=12`
+- Limited memory: `MAX_JOBS=4`
+- CI runtime builds: Parameter not used
+
+For more detailed information about the Docker build system, see the [Docker build guide](../tools/docker/README.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,8 @@ For users who want to explore more specialized features of Linnaeus.
 Resources for those looking to extend or contribute to Polli Linnaeus.
 
 *   **[Model System Overview](./models/model_system_overview.md):** Understand the architectural design, component registries, and how to create new model architectures.
+*   **[CI & Docker Guide](./ci.md):** Learn about the continuous integration setup and Docker image architecture.
+*   **[Docker Build Guide](../tools/docker/README.md):** Detailed documentation on building and maintaining the Linnaeus Docker images.
 *   **[Development Guides](./dev/):** (Link to `docs/dev/` directory if it contains an index or relevant files - e.g., `docs/dev/01_training_loop_and_progress.md`) Explore notes on the training loop, scheduling system, metrics, and other internal design choices.
 *   **[Contributing Guidelines](../../CONTRIBUTING.md):** (To be created) How to contribute to the Polli Linnaeus project.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,12 @@
 [project]
 name = "linnaeus"
-version = "0.1.1-rc6"
+version = "0.1.1"
 description = "Linnaeus: A deep learning framework for taxonomic recognition."
+## Releasing
+# When releasing a new version:
+# 1. Update the version above
+# 2. Tag with proper format: vX.Y.Z for stable, vX.Y.Z-rcN for pre-releases (note the hyphen!)
+# 3. Ensure base Docker images are up-to-date before tagging
 authors = [
     { name = "Caleb Sowers", email = "caleb@polli.ai" },
 ]

--- a/tools/docker/Dockerfile.runtime
+++ b/tools/docker/Dockerfile.runtime
@@ -1,5 +1,7 @@
 # Dockerfile.runtime - Lightweight runtime image that builds on pre-compiled base images
 # This Dockerfile only handles the Linnaeus application layer, not the heavy dependencies
+#
+# IMPORTANT: The main stage MUST be named "runtime" to match the CI workflow target
 
 ARG BASE_TAG=ampere-cu126
 FROM frontierkodiak/linnaeus-base:${BASE_TAG} AS runtime
@@ -27,3 +29,17 @@ RUN uv pip install --system --no-deps -e .[dev] && \
 
 # Default command is bash shell
 CMD ["/bin/bash"]
+
+# ===== Optional Debug Stages =====
+# You can add additional stages after the main runtime stage for local development.
+# These won't affect CI because the workflow explicitly targets the "runtime" stage.
+#
+# Example debug stage with additional tools:
+# FROM runtime AS debug
+# RUN apt-get update && apt-get install -y \
+#     vim \
+#     gdb \
+#     strace \
+#     && rm -rf /var/lib/apt/lists/*
+#
+# Build with: docker buildx build --target debug ...

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,57 +1,55 @@
 # Docker Build Tools for Linnaeus
 
-This directory contains tools for building Docker images for the Linnaeus project using a **two-stage build process** with separate Dockerfiles:
-- `Dockerfile.base` - Builds the heavy base images with CUDA, PyTorch, Flash Attention
-- `Dockerfile.runtime` - Builds lightweight runtime images containing only Linnaeus code
+This directory contains tools for building Docker images for the Linnaeus project using a **slim multi-stage build architecture** with separate Dockerfiles:
+- `Dockerfile.base` - Multi-stage build that produces slim base images (<8GB) with CUDA, PyTorch, and heavy dependencies
+- `Dockerfile.runtime` - Lightweight runtime images (<300MB layer) containing only Linnaeus code
 
-## Overview of the Two-Stage Build
+## Architecture Overview
 
-The Docker build process is split into two stages: a `base` image and a `runtime` image. This approach offers several advantages:
+The Docker build system uses a three-stage architecture designed to fit within GitHub's free runner constraints:
 
-- **Faster Rebuilds:** The `runtime` image, which contains the frequently changing Linnaeus application code, can be rebuilt much faster because the `base` image (with OS dependencies, CUDA, PyTorch, etc.) is cached and only rebuilt when its core components change.
-- **Separation of Concerns:** The `base` image handles the complex setup of the underlying environment, while the `runtime` image focuses solely on the application.
-- **Cleaner Workspace:** Intermediate build tools and artifacts used to compile dependencies like Flash Attention are kept in the `base` stage and do not bloat the final `runtime` image.
+### 1. `builder` Stage (Local Only)
+- **Purpose:** Compiles Flash Attention and installs all dependencies in a virtual environment
+- **Size:** ~40GB (includes CUDA devel headers, build tools, compilation artifacts)
+- **Usage:** Never pushed to registry; exists only during base image builds
+- **Parent:** `nvidia/cuda:*-cudnn-devel-ubuntu22.04`
 
-## The `base` Image
+### 2. `base` Stage (Published)
+- **Purpose:** Slim runtime with CUDA, PyTorch, and all heavy Python dependencies
+- **Size:** 6-8GB uncompressed (<2.5GB compressed on Docker Hub)
+- **Usage:** Built rarely with `BUILDKIT_INLINE_CACHE=1`, pushed to registry
+- **Parent:** `nvidia/cuda:*-runtime-ubuntu22.04` (no devel headers)
 
-- **Purpose:** Contains the foundational software stack that changes infrequently. This includes:
-    - NVIDIA CUDA libraries
-    - PyTorch, TorchVision, TorchAudio
-    - Flash Attention (conditionally installed based on architecture)
-    - Core OS dependencies and Python environment (`python3.11`, `uv`, `ninja`)
-- **Naming Convention:** `frontierkodiak/linnaeus-base:<arch>-<cuda_suffix>-torch<torch_ver_short>-fa<fa_ver_tag>`
-    - Example: `frontierkodiak/linnaeus-base:ampere-cu126-torch2.7.1-fav2`
-    - `<arch>`: `ampere`, `hopper`, `turing`
-    - `<cuda_suffix>`: e.g., `cu126`, `cu128`
-    - `<torch_ver_short>`: e.g., `2.7.1`, `2.8.0rc0`
-    - `<fa_ver_tag>`: `v2`, `v3`, or `none`
-- **When to Rebuild:** The `base` image needs to be manually rebuilt when:
-    - Upgrading PyTorch, CUDA version, or Flash Attention version
-    - Adding new dependencies to `pyproject.toml` (these should be added to `Dockerfile.base`)
-    - Changing compilation flags or system dependencies
-- **How it's Built:** Built using `docker buildx build` targeting the `base` stage in the `Dockerfile`.
+### 3. `runtime` Stage (CI/CD)
+- **Purpose:** Linnaeus application code only
+- **Size:** ~300MB layer on top of base
+- **Usage:** Built automatically by CI on every release
+- **Parent:** `frontierkodiak/linnaeus-base:${BASE_TAG}`
 
-## The `runtime` Image
+## Critical Design Constraints
 
-- **Purpose:** Contains the Linnaeus application code and its Python dependencies. This image is built on top of a specific `base` image. It is designed to be rebuilt frequently as you develop the application.
-- **Naming Convention:** `frontierkodiak/linnaeus-dev:<git_sha>-<arch><tag_suffix>`
-    - Example: `frontierkodiak/linnaeus-dev:abcdef123456-ampere`
-    - `<git_sha>`: Short commit SHA of the Linnaeus repository.
-    - `<arch>`: `ampere`, `hopper`, `turing`
-    - `<tag_suffix>`: Optional user-defined suffix (e.g., `-myfeature`).
-- **How it's Built:** Built using `docker buildx build` targeting the `runtime` stage in the `Dockerfile`. This stage installs the Linnaeus application code using `uv pip install --system --no-deps -e .[dev]`, relying on the `base` image for all shared heavy dependencies. The appropriate `base` image is used as a cache, and the Linnaeus repository is cloned at the specified branch/commit.
+### GitHub Runner Disk Limits
+- **Available disk:** 14GB total
+- **BuildKit reserve:** 3GB (configured via `BUILDKIT_GC_KEEP_STORAGE`)
+- **Usable space:** ~11GB
+- **Our usage:** 8-10GB peak (base image + runtime build + logs)
 
-## Building Docker Images
+### Dependency Management Rule
+⚠️ **IMPORTANT:** Any new dependency added to `pyproject.toml` MUST also be added to `Dockerfile.base`. The runtime build uses `--no-deps` to avoid downloading packages in CI.
 
-Both `base` and `runtime` images are built using `docker buildx build` commands. The system is designed as a two-stage process:
-- **Base images** contain the heavy dependencies and are built manually (rarely)
-- **Runtime images** contain only the Linnaeus application and are built automatically by CI
+## Building Base Images
 
-### Building Base Images
+Base images use a multi-stage build to compile dependencies in the `builder` stage but publish only the slim `base` stage.
 
-Base images must be built with `BUILDKIT_INLINE_CACHE=1` to enable proper layer caching in CI environments.
+### Key Build Arguments
+- `MAX_JOBS`: Controls `ninja` parallelism during Flash Attention compilation (only affects base builds)
+- `BUILDKIT_INLINE_CACHE=1`: **MANDATORY** - enables layer caching for CI
+- `TORCH_CHANNEL`: `stable` or `nightly`
+- `FA_VER`: Flash Attention version (blank to skip on Turing)
 
-**Example for Turing:**
+### Build Commands
+
+**Turing (RTX 2080, T4):**
 ```bash
 docker buildx build \
   --platform linux/amd64 \
@@ -68,7 +66,7 @@ docker buildx build \
   --push .
 ```
 
-**Example for Ampere:**
+**Ampere (RTX 3090, A100):**
 ```bash
 docker buildx build \
   --platform linux/amd64 \
@@ -85,7 +83,7 @@ docker buildx build \
   --push .
 ```
 
-**Example for Hopper (with nightly PyTorch):**
+**Hopper (H100):**
 ```bash
 docker buildx build \
   --platform linux/amd64 \
@@ -100,13 +98,16 @@ docker buildx build \
   --push .
 ```
 
-Note: For Hopper, `FA_VER` is generally not needed as the latest compatible Flash Attention v3 wheel is installed by default when `TORCH_CHANNEL=nightly`. Pass `FA_VER` only if you specifically need to pin to an older v3 tag.
+## Building Runtime Images
 
-### Building Runtime Images
+Runtime images are built from `Dockerfile.runtime` and contain only the Linnaeus application code.
 
-Runtime images are built from the separate `Dockerfile.runtime` and use pre-built base images.
+### Critical Requirements
+- **Stage naming:** The Dockerfile MUST have `FROM ... AS runtime` 
+- **Workflow targeting:** The CI workflow MUST specify `target: runtime`
+- **No heavy dependencies:** Uses `--no-deps` to avoid re-downloading packages
 
-**Example:**
+### Example Build
 ```bash
 docker buildx build \
   --platform linux/amd64 \
@@ -117,65 +118,70 @@ docker buildx build \
   --push .
 ```
 
-Note: Runtime builds should be fast (<2 minutes) as they only install the Linnaeus application code.
+## CI/CD Workflow
 
-## Architecture Configurations (for `base` image)
+The GitHub Actions workflow (`.github/workflows/build-runtime.yml`) automatically builds runtime images on tagged releases.
 
-The following configurations are used for different architectures when building the `base` image:
+### Workflow Features
+1. **Triggers on tags:** `v*.*.*` pattern (e.g., `v0.1.1`, `v0.1.1-rc7`)
+2. **BuildKit disk guard:** Monitors `/tmp` usage to ensure <12GB
+3. **Target specification:** Uses `target: runtime` to skip heavy stages
+4. **Matrix builds:** Parallel builds for turing, ampere, and hopper
 
-### Ampere (e.g., RTX 3090, A100)
-- PyTorch: `2.7.1+cu126` (stable)
-- Flash Attention: `2.7.4.post1` (v2)
+### Tagging Convention
+- **Stable releases:** `vX.Y.Z` (e.g., `v0.1.1`)
+- **Pre-releases:** `vX.Y.Z-rcN` with hyphen (e.g., `v0.1.1-rc7`)
 
-### Turing (e.g., RTX 2080, T4)
-- PyTorch: `2.7.1+cu126` (stable)
-- Flash Attention: Skipped (not supported/installed)
+## Common Issues and Solutions
 
-### Hopper (e.g., H100)
-- PyTorch: Latest nightly wheel from `https://download.pytorch.org/whl/nightly/cu128` (unpinned)
-- Flash Attention: Latest nightly Flash-Attention v3 wheel (unpinned, >=3.0.0)
+### Issue: "target stage runtime could not be found"
+**Solution:** Ensure `Dockerfile.runtime` has `FROM ... AS runtime` on its base image line.
 
-**Important PyTorch Installation Notes:**
-- **Stable channel (Ampere/Turing):** PyTorch versions are explicitly pinned (e.g., `2.7.1`) to ensure reproducibility.
-- **Nightly channel (Hopper/cu128):** PyTorch is installed without version pinning, allowing pip/uv to automatically select the latest available nightly wheel. This is necessary because CUDA 12.8 wheels are only available as rolling nightly releases.
+### Issue: CI disk space errors
+**Solution:** 
+1. Verify base images are <8GB: `docker images | grep linnaeus-base`
+2. Check workflow has `target: runtime` in build-push-action
+3. Ensure `BUILDKIT_GC_KEEP_STORAGE=3g` is set
 
-## Flash Attention Compilation Notes
+### Issue: Missing dependencies in runtime
+**Solution:** Add the dependency to BOTH:
+1. `pyproject.toml` 
+2. `Dockerfile.base` (in the heavy dependencies RUN command)
 
-- Flash Attention is compiled in the `base` stage if applicable for the selected architecture.
-- The `MAX_JOBS` argument controls compilation parallelism (`ninja` is used).
-    - Default `MAX_JOBS=12` is suitable for machines with ample RAM (e.g., 128GB) and CPU cores.
-    - Reduce `MAX_JOBS` (e.g., to 4) on systems with less memory to prevent out-of-memory errors during compilation.
+Then rebuild and push base images before creating a new release.
 
-### Overriding MAX_JOBS with docker buildx
+## Adding Debug Stages (Optional)
 
-You can override the `MAX_JOBS` build argument when building:
+To add optional stages without affecting CI, place them AFTER the main runtime stage:
 
-```bash
-docker buildx build ... --build-arg MAX_JOBS=4 ...
+```dockerfile
+# Main runtime stage (used by CI)
+FROM frontierkodiak/linnaeus-base:${BASE_TAG} AS runtime
+# ... runtime setup ...
+
+# Optional debug stage (for local development)
+FROM runtime AS debug
+RUN apt-get update && apt-get install -y vim gdb
 ```
 
-## Validation
-
-After building your `runtime` image, you can validate it using `validate.sh` (if this script is still maintained and compatible with the new image structure).
-Example:
+CI will continue using the `runtime` stage while developers can build debug images with:
 ```bash
-# Assuming validate.sh is in the same directory
-./validate.sh frontierkodiak/linnaeus-dev:<git_sha>-<arch>
-# e.g. ./validate.sh frontierkodiak/linnaeus-dev:abcdef123456-ampere
+docker buildx build --target debug ...
 ```
-The validation script typically checks for GPU access, CUDA functionality, and may perform a basic application startup test.
 
-## Benefits of the New System
+## Architecture Decision Log
 
-- **Significantly Faster Iteration:** When you change Linnaeus code, only the `runtime` stage is rebuilt, which is much quicker as it doesn't re-install PyTorch or other heavy dependencies.
-- **Consistency:** Ensures all developers use the same base environment.
-- **Simplified Dockerfile:** The main `Dockerfile` is now cleaner and easier to understand.
+### Why Multi-Stage Base Images?
+1. **Builder stage:** Contains 40GB of build tools, headers, and compilation artifacts
+2. **Base stage:** Strips away everything except runtime libraries (<8GB)
+3. **Result:** 70% size reduction enables free GitHub Actions runners
 
-## Common Gotchas
+### Why Separate Dockerfiles?
+1. **Base changes rarely:** PyTorch/CUDA updates ~monthly
+2. **Runtime changes frequently:** Every commit/PR
+3. **Result:** CI builds complete in <2 minutes instead of 15-20 minutes
 
-- **MAX_JOBS Consistency:** The `MAX_JOBS` build argument must be identical across all commands that build the base stage. After the Dockerfile split, it only affects `Dockerfile.base` builds, so CI commands for runtime images should omit it to avoid cache invalidation.
-- **Inline Cache Requirement:** Base images MUST be built with `BUILDKIT_INLINE_CACHE=1` or the GitHub Actions runners won't be able to reuse cached layers. Forgetting this flag will cause full rebuilds in CI.
-- **Nightly PyTorch:** Never pin `TORCH_VER` when `TORCH_CHANNEL=nightly`. Nightly wheels disappear after ~2 weeks, causing build failures.
-- **GitHub Runner Limits:** GitHub's ubuntu-latest runners have only 4 vCPU / 14 GB disk space. The runtime builds are optimized to use <10GB.
-- **Dependency Updates:** When adding new dependencies to `pyproject.toml`, they MUST also be added to `Dockerfile.base` to avoid CI disk space issues. The runtime Dockerfile uses `--no-deps` and expects all dependencies in the base.
-- **Base Image Tags:** After rebuilding base images, update the tags in the GitHub workflow matrix to ensure CI uses the new versions.
+### Why Virtual Environment in Builder?
+1. **Clean separation:** Only `/opt/venv` is copied to final stage
+2. **No pip caches:** Saves ~1GB
+3. **No build artifacts:** Saves ~3GB


### PR DESCRIPTION
## Summary

This PR completes the documentation for the slim Docker build workflow that enables CI/CD on free GitHub runners.

## Changes

### Documentation Updates
- [x] Update `tools/docker/README.md` with final multi-stage architecture documentation
- [x] Add inline comments to `.github/workflows/build-runtime.yml` explaining critical settings
- [x] Clean up `tools/docker/Dockerfile.runtime` with stage naming documentation
- [x] Create comprehensive `docs/ci.md` covering CI/Docker workflow
- [x] Update `docs/index.md` to link Docker documentation
- [x] Add CHANGELOG entry for 0.1.1 release

### Version Update
- [x] Update `pyproject.toml` to stable version 0.1.1
- [x] Add releasing instructions comment in pyproject.toml

## Key Improvements

1. **Architecture Documentation**: Clear explanation of the three-stage build system (builder → base → runtime)
2. **Troubleshooting Guide**: Common issues and solutions for Docker builds
3. **CI Guide**: Step-by-step instructions for adding dependencies and rebuilding base images
4. **Decision Log**: Rationale for the multi-stage architecture

## Context

This completes the Docker workflow optimization that reduced base images from 19-22GB to 6-8GB, enabling CI/CD on free GitHub runners with <2 minute build times.

## Testing

All documentation has been reviewed for accuracy against the actual build commands used in v0.1.1-rc6.