### PR TITLE
Add explicit thread control for PyTorch and OpenCV

### DIFF
--- a/linnaeus/h5data/prefetching_hybrid_dataset.py
+++ b/linnaeus/h5data/prefetching_hybrid_dataset.py
@@ -8,6 +8,10 @@ import h5py
 import numpy as np
 import torch
 
+# CRITICAL: Disable OpenCV's internal threading to prevent thread explosion.
+# Our own ThreadPoolExecutor handles parallelism for I/O.
+cv2.setNumThreads(0)
+
 from linnaeus.aug.base import AugmentationPipeline
 
 from .base_prefetching_dataset import BasePrefetchingDataset

--- a/linnaeus/main.py
+++ b/linnaeus/main.py
@@ -1940,6 +1940,10 @@ if __name__ == "__main__":
     _shutdown_in_progress = False
     _shutdown_lock = threading.RLock()
 
+    # CRITICAL: Limit PyTorch intra-op parallelism to prevent thread explosion
+    # on multi-core CPUs. A small number like 4 is recommended.
+    torch.set_num_threads(4)
+
     # Set up a simple console logger until we create the real logger in main()
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))


### PR DESCRIPTION
Prevents thread explosion on high-core-count systems (56c/112t per NUMA node).

## Changes
- Set `torch.set_num_threads(4)` in main.py to limit PyTorch intra-op parallelism
- Set `cv2.setNumThreads(0)` to disable OpenCV internal threading
- Allows dataloader ThreadPoolExecutor to manage concurrency effectively

## Impact
Reduces thread count from ~170 to ~20-30 per process, eliminating CPU contention and unblocking data pipeline throughput.

Tested on 56-core/112-thread per NUMA node pods where thread explosion was causing severe performance degradation.