### PR TITLE
[perf] Add profiling hooks for mFormerV1 forward

### DIFF
--- a/linnaeus/models/blocks/convnext.py
+++ b/linnaeus/models/blocks/convnext.py
@@ -14,6 +14,7 @@ import torch.utils.checkpoint
 # Assuming these utilities are available
 from linnaeus.models.blocks.drop_path import DropPath
 from linnaeus.utils.logging.logger import get_main_logger
+from linnaeus.utils.profiling_helpers import prof
 
 logger = get_main_logger()
 
@@ -65,17 +66,22 @@ class ConvNeXtBlock(nn.Module):
     def _forward_impl(self, x: torch.Tensor) -> torch.Tensor:
         """Core logic wrapped by checkpointing."""
         input_tensor = x
-        x = self.dwconv(x)
-        x = x.permute(0, 2, 3, 1)  # (N, C, H, W) -> (N, H, W, C)
-        x = self.norm(x)
+        with prof("convnext/dwconv", level=3):
+            x = self.dwconv(x)
+        with prof("convnext/nchw_to_nhwc", level=3):
+            x = x.permute(0, 2, 3, 1)  # (N, C, H, W) -> (N, H, W, C)
+        with prof("convnext/norm", level=3):
+            x = self.norm(x)
         x = self.pwconv1(x)
         x = self.act(x)
         x = self.pwconv2(x)
         if self.gamma is not None:
             x = self.gamma * x
-        x = x.permute(0, 3, 1, 2)  # (N, H, W, C) -> (N, C, H, W)
+        with prof("convnext/nhwc_to_nchw", level=3):
+            x = x.permute(0, 3, 1, 2)  # (N, H, W, C) -> (N, C, H, W)
 
-        x = input_tensor + self.drop_path(x)
+        with prof("convnext/residual", level=3):
+            x = input_tensor + self.drop_path(x)
         return x
 
     def forward(self, x: torch.Tensor, use_checkpoint: bool = False) -> torch.Tensor:

--- a/linnaeus/models/blocks/drop_path.py
+++ b/linnaeus/models/blocks/drop_path.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 
 from linnaeus.utils.logging.logger import get_main_logger
+from linnaeus.utils.profiling_helpers import prof
 
 logger = get_main_logger()
 
@@ -26,9 +27,11 @@ def drop_path(x: torch.Tensor, drop_prob: float = 0.0, training: bool = False) -
         return x
     keep_prob = 1 - drop_prob
     shape = (x.shape[0],) + (1,) * (x.ndim - 1)
-    random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
-    random_tensor = random_tensor.floor()
-    output = x.div(keep_prob) * random_tensor
+    with prof("drop_path/rand", level=3):
+        random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype, device=x.device)
+    with prof("drop_path/scale", level=3):
+        random_tensor = random_tensor.floor()
+        output = x.div(keep_prob) * random_tensor
     if torch.isnan(output).any():
         logger.warning("drop_path resulted in NaN values.")
     return output

--- a/linnaeus/models/blocks/mlp.py
+++ b/linnaeus/models/blocks/mlp.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 
 from linnaeus.utils.logging.logger import get_main_logger
+from linnaeus.utils.profiling_helpers import prof
 
 logger = get_main_logger()
 
@@ -53,7 +54,9 @@ class Mlp(nn.Module):
         """
         x = self.fc1(x)
         x = self.act(x)
-        x = self.drop(x)
+        with prof("mlp/dropout1", level=3):
+            x = self.drop(x)
         x = self.fc2(x)
-        x = self.drop(x)
+        with prof("mlp/dropout2", level=3):
+            x = self.drop(x)
         return x

--- a/linnaeus/models/blocks/rope_2d_mhsa.py
+++ b/linnaeus/models/blocks/rope_2d_mhsa.py
@@ -14,6 +14,7 @@ import torch.utils.checkpoint
 from linnaeus.models.blocks.drop_path import DropPath  # E402: moved to top
 from linnaeus.models.blocks.mlp import Mlp  # E402: moved to top
 from linnaeus.utils.flash_attn_utils import is_flash_attn3_available  # E402: moved to top
+from linnaeus.utils.profiling_helpers import prof
 
 _flash_attn_func_impl = None
 _flash_attn_qkvpacked_func_impl = None  # For completeness if other code uses it
@@ -244,7 +245,7 @@ class RoPE2DAttention(nn.Module):
             if _is_flash_attn_v2_plus_available and _flash_attn_func_impl is not None:
                 try:
                     if not (hasattr(torch, "cuda") and torch.cuda.is_available()):
-                        logger.warning("Flash Attention selected but CUDA not available. Falling back.")
+                        self.logger.warning("Flash Attention selected but CUDA not available. Falling back.")
                     else:
                         device_cap = torch.cuda.get_device_capability()
 
@@ -354,22 +355,23 @@ class RoPE2DAttention(nn.Module):
 
     def _get_current_freqs_cis(self, H: int, W: int, device: torch.device) -> torch.Tensor:
         """Gets or recomputes freqs_cis based on current grid size."""
-        N_img = H * W
-        if self.rope_mixed:
-            # Needs coordinates for the current size
-            t_x, t_y = init_t_xy(W, H, device=device)
-            freqs_cis = compute_mixed_cis(self.freqs.to(device), t_x, t_y)  # Compute complex
-            return freqs_cis.to(torch.complex64)
-        else:
-            # Axial: Check if precomputed size matches
-            if N_img != self.freqs_cis.shape[0]:
-                self.logger.warning(f"RoPE Axial freqs size mismatch ({self.freqs_cis.shape[0]} vs {N_img}). Recomputing.")
-                # Recompute and update buffer (this might be slow if called often)
-                new_freqs_cis = self._precompute_axial_freqs_cis(10000.0).to(device)
-                self.register_buffer("freqs_cis", new_freqs_cis, persistent=False)
-                return new_freqs_cis
+        with prof("rope/get_current_freqs_cis", level=3):
+            N_img = H * W
+            if self.rope_mixed:
+                # Needs coordinates for the current size
+                t_x, t_y = init_t_xy(W, H, device=device)
+                freqs_cis = compute_mixed_cis(self.freqs.to(device), t_x, t_y)  # Compute complex
+                return freqs_cis.to(torch.complex64)
             else:
-                return self.freqs_cis.to(device)
+                # Axial: Check if precomputed size matches
+                if N_img != self.freqs_cis.shape[0]:
+                    self.logger.warning(f"RoPE Axial freqs size mismatch ({self.freqs_cis.shape[0]} vs {N_img}). Recomputing.")
+                    # Recompute and update buffer (this might be slow if called often)
+                    new_freqs_cis = self._precompute_axial_freqs_cis(10000.0).to(device)
+                    self.register_buffer("freqs_cis", new_freqs_cis, persistent=False)
+                    return new_freqs_cis
+                else:
+                    return self.freqs_cis.to(device)
 
     def forward(self, x: torch.Tensor, H: int, W: int) -> torch.Tensor:
         """Forward pass of RoPE attention."""
@@ -379,74 +381,82 @@ class RoPE2DAttention(nn.Module):
         assert N == N_img + N_extra, f"Input sequence length {N} != H*W+extra {N_img + N_extra}"
 
         # QKV projection
-        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4)
-        q, k, v = qkv.unbind(0)  # Shape: (B, num_heads, N, head_dim)
+        with prof("rope/qkv_projection", level=3):
+            qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, self.head_dim).permute(2, 0, 3, 1, 4)
+            q, k, v = qkv.unbind(0)  # Shape: (B, num_heads, N, head_dim)
 
         # Split extra tokens and image tokens
-        q_extra, q_img = q.split([N_extra, N_img], dim=2)
-        k_extra, k_img = k.split([N_extra, N_img], dim=2)
-        v_extra, v_img = v.split([N_extra, N_img], dim=2)
+        with prof("rope/split_tokens", level=3):
+            q_extra, q_img = q.split([N_extra, N_img], dim=2)
+            k_extra, k_img = k.split([N_extra, N_img], dim=2)
+            v_extra, v_img = v.split([N_extra, N_img], dim=2)
 
         # Compute RoPE frequencies (cis) based on current H, W
-        freqs_cis = self._get_current_freqs_cis(H, W, device=x.device)
+        with prof("rope/freqs_compute", level=3):
+            freqs_cis = self._get_current_freqs_cis(H, W, device=x.device)
 
         # Apply RoPE to image tokens only
-        q_img_rot, k_img_rot = apply_rotary_emb(q_img, k_img, freqs_cis)
+        with prof("rope/apply_rotary_emb", level=3):
+            q_img_rot, k_img_rot = apply_rotary_emb(q_img, k_img, freqs_cis)
 
         # Concatenate back
-        q_final = torch.cat([q_extra, q_img_rot], dim=2)
-        k_final = torch.cat([k_extra, k_img_rot], dim=2)
-        v_final = torch.cat([v_extra, v_img], dim=2)  # Use original v
+        with prof("rope/concat_tokens", level=3):
+            q_final = torch.cat([q_extra, q_img_rot], dim=2)
+            k_final = torch.cat([k_extra, k_img_rot], dim=2)
+            v_final = torch.cat([v_extra, v_img], dim=2)  # Use original v
 
         # Apply scaling
         q_final = q_final * self.scale
 
         # Use Flash Attention implementation if available and enabled
         if self.use_flash_attn_impl and q_final.is_cuda:
-            # Flash Attention expects inputs in [batch_size, seq_len, num_heads, head_dim]
-            # Reshape our inputs to [batch_size, seq_len, num_heads, head_dim]
-            q_final_perm = q_final.permute(0, 2, 1, 3)  # [B, N, H, D]
-            k_final_perm = k_final.permute(0, 2, 1, 3)  # [B, N, H, D]
-            v_final_perm = v_final.permute(0, 2, 1, 3)  # [B, N, H, D]
+            with prof("rope/flash_attention", level=3):
+                # Flash Attention expects inputs in [batch_size, seq_len, num_heads, head_dim]
+                # Reshape our inputs to [batch_size, seq_len, num_heads, head_dim]
+                q_final_perm = q_final.permute(0, 2, 1, 3)  # [B, N, H, D]
+                k_final_perm = k_final.permute(0, 2, 1, 3)  # [B, N, H, D]
+                v_final_perm = v_final.permute(0, 2, 1, 3)  # [B, N, H, D]
 
-            # *** START FIX ***
-            # Explicitly cast inputs to float16 for FlashAttention
-            input_dtype = torch.float16
-            # Optional: Check if bf16 is supported and preferred, but fp16 is safer baseline
-            # if torch.cuda.is_bf16_supported():
-            #     input_dtype = torch.bfloat16
+                # *** START FIX ***
+                # Explicitly cast inputs to float16 for FlashAttention
+                input_dtype = torch.float16
+                # Optional: Check if bf16 is supported and preferred, but fp16 is safer baseline
+                # if torch.cuda.is_bf16_supported():
+                #     input_dtype = torch.bfloat16
 
-            q_fa = q_final_perm.to(input_dtype)
-            k_fa = k_final_perm.to(input_dtype)
-            v_fa = v_final_perm.to(input_dtype)
+                q_fa = q_final_perm.to(input_dtype)
+                k_fa = k_final_perm.to(input_dtype)
+                v_fa = v_final_perm.to(input_dtype)
 
-            # Call flash_attn_func with casted tensors
-            # No need for autocast(enabled=False) context here
-            context = flash_attn_func(
-                q_fa,
-                k_fa,
-                v_fa,
-                dropout_p=self.attn_drop.p if self.training else 0.0,
-                softmax_scale=self.scale,  # Pass pre-computed scale
-                causal=False,
-            )
-            # *** END FIX ***
+                # Call flash_attn_func with casted tensors
+                # No need for autocast(enabled=False) context here
+                context = flash_attn_func(
+                    q_fa,
+                    k_fa,
+                    v_fa,
+                    dropout_p=self.attn_drop.p if self.training else 0.0,
+                    softmax_scale=self.scale,  # Pass pre-computed scale
+                    causal=False,
+                )
+                # *** END FIX ***
 
-            # Output shape is (B, N, num_heads, head_dim)
-            # Reshape to (B, N, C) - ensure output matches original dtype
-            out = context.permute(0, 2, 1, 3).to(x.dtype)  # Cast back to original dtype
+                # Output shape is (B, N, num_heads, head_dim)
+                # Reshape to (B, N, C) - ensure output matches original dtype
+                out = context.permute(0, 2, 1, 3).to(x.dtype)  # Cast back to original dtype
         else:
-            # Standard attention implementation
-            # Use float32 for attention calculation for stability
-            attn = q_final.float() @ k_final.float().transpose(-2, -1)  # [B, H, N, N]
-            attn = self.softmax(attn).type_as(v_final)  # Cast back to original dtype
-            attn = self.attn_drop(attn)
-            out = attn @ v_final  # [B, H, N, D]
+            with prof("rope/standard_attention", level=3):
+                # Standard attention implementation
+                # Use float32 for attention calculation for stability
+                attn = q_final.float() @ k_final.float().transpose(-2, -1)  # [B, H, N, N]
+                attn = self.softmax(attn).type_as(v_final)  # Cast back to original dtype
+                attn = self.attn_drop(attn)
+                out = attn @ v_final  # [B, H, N, D]
 
         # Output projection
-        out = out.transpose(1, 2).reshape(B, N, C)
-        out = self.proj(out)
-        out = self.proj_drop(out)
+        with prof("rope/output_projection", level=3):
+            out = out.transpose(1, 2).reshape(B, N, C)
+            out = self.proj(out)
+            out = self.proj_drop(out)
 
         return out
 
@@ -553,7 +563,8 @@ class RoPE2DMHSABlock(nn.Module):
         identity = x
 
         # --- Attention + Residual ---
-        x_norm1 = self.norm1(x)
+        with prof("rope_block/norm1", level=3):
+            x_norm1 = self.norm1(x)
         # Check if grid size changed unexpectedly - triggers recompute in attn if needed
         if (H, W) != self.img_grid_size:
             # Log only if size actually changed from expected block init size
@@ -563,30 +574,35 @@ class RoPE2DMHSABlock(nn.Module):
                 )
                 self._logged_grid_warning = (H, W)  # Log only once per size change
 
-        if use_checkpoint and self.training:
-            # self.logger.debug(f"[GC_INTERNAL RoPE Block] Applying CHECKPOINT to Attention")
-            attn_output = torch.utils.checkpoint.checkpoint(
-                self._attn_impl,
-                x_norm1,
-                H,
-                W,  # Pass current H, W
-                use_reentrant=False,
-                preserve_rng_state=True,
-            )
-        else:
-            attn_output = self._attn_impl(x_norm1, H, W)
+        with prof("rope_block/attn", level=3):
+            if use_checkpoint and self.training:
+                # self.logger.debug(f"[GC_INTERNAL RoPE Block] Applying CHECKPOINT to Attention")
+                attn_output = torch.utils.checkpoint.checkpoint(
+                    self._attn_impl,
+                    x_norm1,
+                    H,
+                    W,  # Pass current H, W
+                    use_reentrant=False,
+                    preserve_rng_state=True,
+                )
+            else:
+                attn_output = self._attn_impl(x_norm1, H, W)
 
-        x = identity + self.drop_path(attn_output)
+        with prof("rope_block/residual_attn", level=3):
+            x = identity + self.drop_path(attn_output)
 
         # --- MLP + Residual ---
         identity_mlp = x  # Store identity for the MLP residual
-        x_norm2 = self.norm2(x)
-        if use_checkpoint and self.training:
-            # logger.debug(f"[GC_INTERNAL RoPE Block] Applying CHECKPOINT to MLP")
-            mlp_output = torch.utils.checkpoint.checkpoint(self._mlp_impl, x_norm2, use_reentrant=False, preserve_rng_state=True)
-        else:
-            mlp_output = self._mlp_impl(x_norm2)
+        with prof("rope_block/norm2", level=3):
+            x_norm2 = self.norm2(x)
+        with prof("rope_block/mlp", level=3):
+            if use_checkpoint and self.training:
+                # logger.debug(f"[GC_INTERNAL RoPE Block] Applying CHECKPOINT to MLP")
+                mlp_output = torch.utils.checkpoint.checkpoint(self._mlp_impl, x_norm2, use_reentrant=False, preserve_rng_state=True)
+            else:
+                mlp_output = self._mlp_impl(x_norm2)
 
-        x = identity_mlp + self.drop_path(mlp_output)
+        with prof("rope_block/residual_mlp", level=3):
+            x = identity_mlp + self.drop_path(mlp_output)
 
         return x

--- a/linnaeus/models/heads/conditional_classifier_head.py
+++ b/linnaeus/models/heads/conditional_classifier_head.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from linnaeus.utils.logging.logger import get_main_logger
+from linnaeus.utils.profiling_helpers import prof
 
 # Importing TaxonomyTree
 try:
@@ -161,35 +162,28 @@ class ConditionalClassifierHead(BaseHierarchicalHead):
 
         # 1. Compute base logits for all levels
         all_logits: dict[str, torch.Tensor] = {}
-        for task_key in self.task_keys:
-            if task_key not in self.level_classifiers:
-                raise RuntimeError(f"Missing classifier for task '{task_key}' in ConditionalClassifierHead.")
-            all_logits[task_key] = self.level_classifiers[task_key](x)
+        with prof("head/conditional/base_logits", level=3):
+            for task_key in self.task_keys:
+                if task_key not in self.level_classifiers:
+                    raise RuntimeError(f"Missing classifier for task '{task_key}' in ConditionalClassifierHead.")
+                all_logits[task_key] = self.level_classifiers[task_key](x)
 
         # 2. Apply conditional refinement (top-down)
-        refined_logits = all_logits.copy()  # Start with base logits
+        refined_logits = all_logits.copy()
+        with prof("head/conditional/refine", level=3):
+            for i in range(len(self.task_keys) - 1):
+                parent_task = self.task_keys[i]
+                child_task = self.task_keys[i + 1]
+                pair_key = f"{parent_task}_{child_task}"
 
-        for i in range(len(self.task_keys) - 1):
-            parent_task = self.task_keys[i]
-            child_task = self.task_keys[i + 1]
-            pair_key = f"{parent_task}_{child_task}"
-
-            matrix_buffer_name = f"hmatrix_{pair_key}"
-            if hasattr(self, matrix_buffer_name):
-                # Get parent routing probabilities using the *refined* logits from the previous step
-                parent_probs = self._compute_routing_probabilities(refined_logits[parent_task], parent_task)  # [B, num_parent_classes]
-
-                hierarchy_matrix = getattr(self, matrix_buffer_name)  # [num_parent, num_child]
-
-                # Calculate hierarchy weights (prior for children based on parents)
-                hierarchy_weights = torch.matmul(parent_probs, hierarchy_matrix)  # [B, num_child_classes]
-                hierarchy_weights = hierarchy_weights + 1e-10  # Epsilon for log stability
-
-                # Refine child logits: Logits = BaseLogits + LogPrior
-                # Use all_logits (base) here, as refinement is cumulative based on parent probs
-                refined_logits[child_task] = all_logits[child_task] + torch.log(hierarchy_weights)
-            # else: # No warning needed if matrix simply doesn't exist (sparse hierarchy)
-            # Logits remain as base_logits[child_task] via the initial copy
+                matrix_buffer_name = f"hmatrix_{pair_key}"
+                if hasattr(self, matrix_buffer_name):
+                    parent_probs = self._compute_routing_probabilities(refined_logits[parent_task], parent_task)
+                    hierarchy_matrix = getattr(self, matrix_buffer_name)
+                    hierarchy_weights = torch.matmul(parent_probs, hierarchy_matrix)
+                    hierarchy_weights = hierarchy_weights + 1e-10
+                    refined_logits[child_task] = all_logits[child_task] + torch.log(hierarchy_weights)
+                # else: remain as base logits
 
         # 3. Return only the logits for the primary task key
         if self.primary_task_key not in refined_logits:

--- a/linnaeus/models/heads/hierarchical_softmax_head.py
+++ b/linnaeus/models/heads/hierarchical_softmax_head.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from linnaeus.utils.logging.logger import get_main_logger
+from linnaeus.utils.profiling_helpers import prof
 
 # Importing TaxonomyTree
 try:
@@ -131,36 +132,28 @@ class HierarchicalSoftmaxHead(BaseHierarchicalHead):
 
         # 1. Compute base logits for each task level independently
         base_logits: dict[str, torch.Tensor] = {}
-        for task_key in self.task_keys:
-            if task_key not in self.task_classifiers:
-                # This should not happen if __init__ is correct
-                raise RuntimeError(f"Missing classifier for task '{task_key}' in HierarchicalSoftmaxHead.")
-            base_logits[task_key] = self.task_classifiers[task_key](x)
+        with prof("head/hsm/base_logits", level=3):
+            for task_key in self.task_keys:
+                if task_key not in self.task_classifiers:
+                    raise RuntimeError(f"Missing classifier for task '{task_key}' in HierarchicalSoftmaxHead.")
+                base_logits[task_key] = self.task_classifiers[task_key](x)
 
         # 2. Apply hierarchical structure to refine logits level by level (top-down)
-        refined_logits = base_logits.copy()  # Start with base logits
+        refined_logits = base_logits.copy()
+        with prof("head/hsm/refine", level=3):
+            for i in range(len(self.task_keys) - 1):
+                parent_task = self.task_keys[i]
+                child_task = self.task_keys[i + 1]
+                pair_key = f"{parent_task}_{child_task}"
 
-        for i in range(len(self.task_keys) - 1):
-            parent_task = self.task_keys[i]
-            child_task = self.task_keys[i + 1]
-            pair_key = f"{parent_task}_{child_task}"  # Key structure from tree method
-
-            matrix_buffer_name = f"hmatrix_{pair_key}"
-            if hasattr(self, matrix_buffer_name):
-                # Get parent probabilities (using potentially refined logits from previous step)
-                parent_probs = F.softmax(refined_logits[parent_task], dim=1)  # [B, num_parent]
-
-                hierarchy_matrix = getattr(self, matrix_buffer_name)  # [num_parent, num_child]
-
-                # Calculate prior probability for children based on parent probs
-                hierarchy_weights = torch.matmul(parent_probs, hierarchy_matrix)  # [B, num_child]
-                hierarchy_weights = hierarchy_weights + 1e-10  # Epsilon for log stability
-
-                # Refine child logits: Z_child_refined = Z_child_base + log(Prior)
-                refined_logits[child_task] = base_logits[child_task] + torch.log(hierarchy_weights)
-            # else: # No warning needed here if matrix simply doesn't exist (sparse hierarchy)
-            # logger.debug(f"No hierarchy matrix for {pair_key}, {child_task} logits remain unrefined by {parent_task}.")
-            # refined_logits[child_task] = base_logits[child_task] # Already copied
+                matrix_buffer_name = f"hmatrix_{pair_key}"
+                if hasattr(self, matrix_buffer_name):
+                    parent_probs = F.softmax(refined_logits[parent_task], dim=1)
+                    hierarchy_matrix = getattr(self, matrix_buffer_name)
+                    hierarchy_weights = torch.matmul(parent_probs, hierarchy_matrix)
+                    hierarchy_weights = hierarchy_weights + 1e-10
+                    refined_logits[child_task] = base_logits[child_task] + torch.log(hierarchy_weights)
+                # else: remain as base logits
 
         # 3. Return only the logits for the primary task key associated with this head instance
         if self.primary_task_key not in refined_logits:

--- a/linnaeus/models/mFormerV1.py
+++ b/linnaeus/models/mFormerV1.py
@@ -80,7 +80,7 @@ class mFormerV1(BaseModel):
                 f"Example for ConvNeXt-S: [3, 3, 27, 3], not just [3, 3].\n"
                 f"This is a known YACS limitation - partial list overrides don't work as expected."
             )
-        
+
         if len(convnext_dims) != 4:
             raise ValueError(
                 f"CONVNEXT_STAGES.DIMS must have exactly 4 elements, got {len(convnext_dims)}.\n"
@@ -88,7 +88,7 @@ class mFormerV1(BaseModel):
                 f"Expected format for ConvNeXt-S: [96, 192, 384, 768].\n"
                 f"You must specify ALL 4 values due to YACS list replacement behavior."
             )
-        
+
         # Additional validation for RoPE with clearer error messages
         if len(rope_depths) != 2:
             raise ValueError(
@@ -97,7 +97,7 @@ class mFormerV1(BaseModel):
                 f"Expected format: [10, 2] or similar.\n"
                 f"You must specify both values due to YACS list replacement behavior."
             )
-        
+
         if len(rope_dims) != 2:
             raise ValueError(
                 f"ROPE_STAGES.DIMS must have exactly 2 elements, got {len(rope_dims)}.\n"
@@ -105,9 +105,9 @@ class mFormerV1(BaseModel):
                 f"Expected format: [384, 768] matching ConvNeXt dims[2:4].\n"
                 f"You must specify both values due to YACS list replacement behavior."
             )
-        
+
         # Log the actual configuration being used for debugging
-        logger.info(f"[mFormerV1] Configuration validated successfully:")
+        logger.info("[mFormerV1] Configuration validated successfully:")
         logger.info(f"  ConvNeXt depths: {convnext_depths} (using stages 0-1: {convnext_depths[:2]})")
         logger.info(f"  ConvNeXt dims: {convnext_dims}")
         logger.info(f"  RoPE depths: {rope_depths}")
@@ -436,27 +436,25 @@ class mFormerV1(BaseModel):
 
         # --- Stage 0 (ConvNeXt Stage 1) ---
         with prof("model/convnext_stage_0", level=2):
-            # Iterate through blocks in stages[0] (ModuleList)
             for blk in self.stages[0]:
                 x = blk(x, use_checkpoint=use_checkpoint)
-            # H, W remain unchanged as ConvNeXt blocks don't change resolution
-
-            x = self.downsample_layers[0](x)  # Downsample 1: D0->D1, H/8, W/8
+        with prof("model/downsample_0", level=2):
+            x = self.downsample_layers[0](x)  # D0->D1, H/8, W/8
             H, W = x.shape[2], x.shape[3]
 
         # --- Stage 1 (ConvNeXt Stage 2) ---
         with prof("model/convnext_stage_1", level=2):
-            # Iterate through blocks in stages[1] (ModuleList)
             for blk in self.stages[1]:
                 x = blk(x, use_checkpoint=use_checkpoint)
-            # H, W remain unchanged
-
-            x = self.downsample_layers[1](x)  # Downsample 2: D1->D2, H/16, W/16
+        with prof("model/downsample_1", level=2):
+            x = self.downsample_layers[1](x)  # D1->D2, H/16, W/16
             H, W = x.shape[2], x.shape[3]
 
         # --- RoPE Stage 3 ---
         with prof("model/rope_stage_3", level=2):
-            x = x.flatten(2).transpose(1, 2)  # (B, H*W, D2)
+            with prof("model/rope_stage_3/flatten", level=3):
+                x = x.flatten(2).transpose(1, 2)  # (B, H*W, D2)
+
             # Prepare extras_1
             cls_1 = self.cls_token_1.expand(B, -1, -1)  # (B, 1, D2)
             extras_1 = [cls_1]
@@ -465,20 +463,22 @@ class mFormerV1(BaseModel):
                     for comp_name, comp_info in self.meta_components.items():
                         start, end = (comp_info["offset"], comp_info["offset"] + comp_info["dim"])
                         meta_head = getattr(self, f"meta_{comp_name.lower()}_head_1")
-                        extras_1.append(meta_head(meta[:, start:end]).unsqueeze(1))
+                        with prof(f"model/rope_stage_3/meta_{comp_name}", level=3):
+                            extras_1.append(meta_head(meta[:, start:end]).unsqueeze(1))
                 else:  # Legacy
                     chunks = torch.split(meta, self.meta_dims, dim=1)
                     for i, c_ in enumerate(chunks):
                         meta_head_1 = getattr(self, f"meta_{i + 1}_head_1")
-                        extras_1.append(meta_head_1(c_).unsqueeze(1))
+                        with prof(f"model/rope_stage_3/meta_{i + 1}", level=3):
+                            extras_1.append(meta_head_1(c_).unsqueeze(1))
 
-            x = torch.cat([*extras_1, x], dim=1)  # (B, N_extra + H*W, D2)
+            with prof("model/rope_stage_3/concat", level=3):
+                x = torch.cat([*extras_1, x], dim=1)  # (B, N_extra + H*W, D2)
 
             # Apply RoPE Stage 3 blocks (index 2)
-            for blk in self.stages[2]:  # RoPE Stage 3 is index 2
+            for blk in self.stages[2]:
                 x = blk(x, H=H, W=W, use_checkpoint=use_checkpoint)
-            x = self.norm_1(x)  # Norm after stage 3
-            H, W = H, W  # Dimensions unchanged by RoPE blocks
+            x = self.norm_1(x)
 
         # Handle cls_1 path
         if not self.only_last_cls:
@@ -486,36 +486,41 @@ class mFormerV1(BaseModel):
             cls_1_final = self.cl_1_fc(cls_1_final)  # Project D2 -> D3
 
         # Prepare for Stage 4
-        x = x[:, self.extra_token_num :, :]  # Get patch tokens (B, H*W, D2)
-        x = x.transpose(1, 2).reshape(B, -1, H, W)  # (B, D2, H, W)
-        x = self.downsample_layers[2](x)  # Downsample 3: D2->D3, H/32, W/32
-        H, W = x.shape[2], x.shape[3]
-        x = x.flatten(2).transpose(1, 2)  # (B, H*W, D3)
+        x = x[:, self.extra_token_num :, :]  # (B, H*W, D2)
+        with prof("model/rope_stage_3/unflatten", level=3):
+            x = x.transpose(1, 2).reshape(B, -1, H, W)  # (B, D2, H, W)
+        with prof("model/downsample_2", level=2):
+            x = self.downsample_layers[2](x)  # D2->D3, H/32, W/32
+            H, W = x.shape[2], x.shape[3]
+        with prof("model/rope_stage_4/flatten", level=3):
+            x = x.flatten(2).transpose(1, 2)  # (B, H*W, D3)
 
         # --- RoPE Stage 4 ---
         with prof("model/rope_stage_4", level=2):
             # Prepare extras_2
-            cls_2 = self.cls_token_2.expand(B, -1, -1)  # (B, 1, D3)
+            cls_2 = self.cls_token_2.expand(B, -1, -1)
             extras_2 = [cls_2]
             if self.use_meta and meta is not None:
                 if hasattr(self, "meta_components") and self.meta_components:
                     for comp_name, comp_info in self.meta_components.items():
                         start, end = (comp_info["offset"], comp_info["offset"] + comp_info["dim"])
                         meta_head = getattr(self, f"meta_{comp_name.lower()}_head_2")
-                        extras_2.append(meta_head(meta[:, start:end]).unsqueeze(1))
+                        with prof(f"model/rope_stage_4/meta_{comp_name}", level=3):
+                            extras_2.append(meta_head(meta[:, start:end]).unsqueeze(1))
                 else:  # Legacy
                     chunks2 = torch.split(meta, self.meta_dims, dim=1)
                     for i, c_ in enumerate(chunks2):
                         meta_head_2 = getattr(self, f"meta_{i + 1}_head_2")
-                        extras_2.append(meta_head_2(c_).unsqueeze(1))
+                        with prof(f"model/rope_stage_4/meta_{i + 1}", level=3):
+                            extras_2.append(meta_head_2(c_).unsqueeze(1))
 
-            x = torch.cat([*extras_2, x], dim=1)  # (B, N_extra + H*W, D3)
+            with prof("model/rope_stage_4/concat", level=3):
+                x = torch.cat([*extras_2, x], dim=1)  # (B, N_extra + H*W, D3)
 
-            # Apply RoPE Stage 4 blocks (index 3)
-            for blk in self.stages[3]:  # RoPE Stage 4 is index 3
+            for blk in self.stages[3]:
                 x = blk(x, H=H, W=W, use_checkpoint=use_checkpoint)
-            x = self.norm_2(x)  # Norm after stage 4
-            cls_2_final = x[:, 0:1, :]  # (B, 1, D3)
+            x = self.norm_2(x)
+            cls_2_final = x[:, 0:1, :]
 
         # --- Aggregation ---
         with prof("model/aggregation", level=2):
@@ -540,6 +545,8 @@ class mFormerV1(BaseModel):
     ) -> dict[str, torch.Tensor]:
         """Forward pass including classification heads."""
         feats = self.forward_features(x, meta, force_checkpointing=force_checkpointing)
-        # Pass features to each classification head
-        out = {t: head(feats) for (t, head) in self.head.items()}
+        out: dict[str, torch.Tensor] = {}
+        for t, head in self.head.items():
+            with prof(f"head/{t}", level=2):
+                out[t] = head(feats)
         return out


### PR DESCRIPTION
## Summary
- instrument mFormerV1 forward path with per-stage downsample, token reshape, meta head and classification head profiling
- add dropout timing in Mlp and profile ConditionalClassifierHead and HierarchicalSoftmaxHead phases

## Testing
- `ruff format linnaeus/models/mFormerV1.py linnaeus/models/blocks/mlp.py linnaeus/models/heads/conditional_classifier_head.py linnaeus/models/heads/hierarchical_softmax_head.py`
- `ruff check --fix --exit-zero linnaeus/models/mFormerV1.py linnaeus/models/blocks/mlp.py linnaeus/models/heads/conditional_classifier_head.py linnaeus/models/heads/hierarchical_softmax_head.py`
- `ruff check --exit-zero .` *(failures: multiple style warnings, e.g., F403, E402)*
- `python -m pytest -q` *(fails: ModuleNotFoundError: gymnasium; ImportError: load_env_from_yaml)*

------
https://chatgpt.com/codex/tasks/task_e_688fc6b8af10832e85ff057c5055d63e