### PR TITLE
Use docs-brand latest + wordmarks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,12 +10,12 @@ theme:
     - navigation.tabs
     - navigation.top
     - search.suggest
-  logo: https://assets.polli.ai/docs-brand/v1.0.3/wordmarks/linnaeus.svg
-  logo_dark: https://assets.polli.ai/docs-brand/v1.0.3/wordmarks/linnaeus.svg
+  logo: https://assets.polli.ai/docs-brand/latest/wordmarks/linnaeus.svg
+  logo_dark: https://assets.polli.ai/docs-brand/latest/wordmarks/linnaeus.svg
 extra_css:
-  - https://assets.polli.ai/docs-brand/v1.0.3/polli-brand.css
+  - https://assets.polli.ai/docs-brand/latest/polli-brand.css
 extra_javascript:
-  - https://assets.polli.ai/docs-brand/v1.0.3/polli-brand.js
+  - https://assets.polli.ai/docs-brand/latest/polli-brand.js
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Switch MkDocs brand kit references to `latest` and set theme wordmarks via the assets host.\n\n- extra_css / extra_javascript → https://assets.polli.ai/docs-brand/latest/\n- theme.logo / theme.logo_dark → assets wordmarks for this project\n\nRationale:\n- Avoids pinning to a specific kit version; enables immediate fixes.\n- Co-brand header is injected by polli-brand.js (wide: Polli + Product; narrow: Product).\n- Alt/labels set to "Polli {Product}".\n\nNo content changes; styling-only.