### PR TITLE
chore: sync public inference and docs follow-up from linnaeus-dev

### DIFF
--- a/docs/advanced_topics/hierarchical_approaches.md
+++ b/docs/advanced_topics/hierarchical_approaches.md
@@ -199,19 +199,28 @@ The standard and recommended solution provided by PyTorch for this scenario is t
 ```python
 # Inside main.py
 
-find_unused = config.DISTRIBUTED.DDP.find_unused_parameters # Default from config
+ddp_kwargs = {
+    "find_unused_parameters": config.DISTRIBUTED.DDP.find_unused_parameters,
+    "gradient_as_bucket_view": config.DISTRIBUTED.DDP.gradient_as_bucket_view,
+    "bucket_cap_mb": config.DISTRIBUTED.DDP.bucket_cap_mb,
+    "static_graph": config.DISTRIBUTED.DDP.static_graph,
+}
 # FORCE True if using GradNorm with hierarchical heads
 if config.LOSS.GRAD_WEIGHTING.TASK.TYPE == 'gradnorm' and \
    any(h.get("TYPE", "").startswith(("Hierarchical", "Conditional"))
        for h in config.MODEL.CLASSIFICATION.HEADS.values()):
-    if not find_unused:
+    if not ddp_kwargs["find_unused_parameters"]:
         logger.warning("GradNorm + Hierarchical Heads require find_unused_parameters=True for DDP. Overriding.")
-    find_unused = True
+    ddp_kwargs["find_unused_parameters"] = True
 
-model = DDP(model, device_ids=[local_rank], find_unused_parameters=find_unused)
+model = DDP(model, device_ids=[local_rank], **ddp_kwargs)
 ```
 
 -   **Effect:** This tells DDP to dynamically detect which parameters were *actually* used in the backward pass and only wait for those gradients, ignoring parameters that didn't receive gradients (like the unused shared classifiers during a specific GradNorm task backward).
+-   **Bucket truthfulness:** Other supported DDP wrap-time settings such as
+    `gradient_as_bucket_view`, `bucket_cap_mb`, and `static_graph` should still
+    follow the operator config directly; only `find_unused_parameters` gets the
+    GradNorm safety override.
 -   **Trade-off:** Setting `find_unused_parameters=True` introduces a small performance overhead during the backward pass as DDP needs to analyze the computation graph. However, it ensures correctness when using complex architectures like shared-parameter hierarchical heads with GradNorm.
 -   **Current Implementation:** linnaeus automatically forces this setting in `main.py` when `LOSS.GRAD_WEIGHTING.TASK.TYPE` is `'gradnorm'` to prevent the DDP error.
 
@@ -231,15 +240,20 @@ As noted in section 5.2, using GradNorm with DDP requires setting `find_unused_p
 
 ```python
 # In main.py
-find_unused = config.DISTRIBUTED.DDP.find_unused_parameters  # Default from config
+ddp_kwargs = {
+    "find_unused_parameters": config.DISTRIBUTED.DDP.find_unused_parameters,
+    "gradient_as_bucket_view": config.DISTRIBUTED.DDP.gradient_as_bucket_view,
+    "bucket_cap_mb": config.DISTRIBUTED.DDP.bucket_cap_mb,
+    "static_graph": config.DISTRIBUTED.DDP.static_graph,
+}
 
 # Force find_unused_parameters=True for all GradNorm usage
 if config.LOSS.GRAD_WEIGHTING.TASK.GRADNORM_ENABLED:
-    if not find_unused:
+    if not ddp_kwargs["find_unused_parameters"]:
         logger.warning("Forcing find_unused_parameters=True for DDP because GradNorm is enabled")
-    find_unused = True
+    ddp_kwargs["find_unused_parameters"] = True
     
-model = DDP(model, device_ids=[local_rank], find_unused_parameters=find_unused)
+model = DDP(model, device_ids=[local_rank], **ddp_kwargs)
 ```
 
 This setting is critical for preventing deadlocks during distributed communication, especially when GradNorm performs separate forward and backward passes for each task.

--- a/linnaeus/config.py
+++ b/linnaeus/config.py
@@ -104,6 +104,10 @@ _C.EXPERIMENT.WANDB.ENABLED = False
 # Note: This is distinct from TRAIN.AUTO_RESUME - when loading from a checkpoint with
 # a wandb_run_id, we always resume that wandb run regardless of this setting.
 _C.EXPERIMENT.WANDB.RESUME = False
+# Controls WandB behavior for full-state checkpoint resumes.
+# - "same_run": restore the checkpoint wandb_run_id and continue the same remote run.
+# - "fresh_run": keep training-state resume but fork a new WandB run explicitly.
+_C.EXPERIMENT.WANDB.CHECKPOINT_RESUME_POLICY = "same_run"
 _C.EXPERIMENT.WANDB.KEY = ""  # Defaults to reading from env var WANDB_KEY if empty
 # Run ID can be manually specified to resume a specific wandb run.
 # This is typically not needed as run_ids are automatically loaded from checkpoints,

--- a/linnaeus/models/dinov3_vnext.py
+++ b/linnaeus/models/dinov3_vnext.py
@@ -24,6 +24,19 @@ from .blocks.query_token_adapter import MetaTokenEncoder, QueryTokenAdapter
 logger = get_main_logger()
 
 
+def get_disabled_optional_module_state_stems(config: CN) -> tuple[str, ...]:
+    stems: list[str] = []
+    if not bool(config.MODEL.META_ADAPTER.ENABLED):
+        stems.extend(["meta_encoder", "meta_adapter", "query_tokens"])
+    elif int(config.MODEL.META_ADAPTER.NUM_QUERIES) <= 0:
+        stems.append("query_tokens")
+    if not bool(config.MODEL.FOREGROUNDNESS.ENABLED):
+        stems.append("foreground_head")
+    if not bool(config.MODEL.MIL.ENABLED):
+        stems.append("mil_pool")
+    return tuple(stems)
+
+
 class DinoV3Backbone(nn.Module):
     def __init__(
         self,
@@ -129,35 +142,46 @@ class DinoV3MultiHead(BaseModel):
 
         self.use_meta_adapter = bool(config.MODEL.META_ADAPTER.ENABLED)
         self.meta_dims = self._resolve_meta_dims(config)
-        self.meta_encoder = MetaTokenEncoder(self.meta_dims, self.embed_dim)
-        self.meta_adapter = QueryTokenAdapter(
-            embed_dim=self.embed_dim,
-            num_layers=config.MODEL.META_ADAPTER.NUM_LAYERS,
-            num_heads=config.MODEL.META_ADAPTER.NUM_HEADS,
-            mlp_ratio=config.MODEL.META_ADAPTER.MLP_RATIO,
-            dropout=config.MODEL.META_ADAPTER.DROPOUT,
-            use_self_attn=config.MODEL.META_ADAPTER.USE_SELF_ATTN,
-        )
         self.num_queries = int(config.MODEL.META_ADAPTER.NUM_QUERIES)
-        if self.num_queries > 0:
-            self.query_tokens = nn.Parameter(torch.zeros(1, self.num_queries, self.embed_dim))
+        if self.use_meta_adapter:
+            self.meta_encoder = MetaTokenEncoder(self.meta_dims, self.embed_dim)
+            self.meta_adapter = QueryTokenAdapter(
+                embed_dim=self.embed_dim,
+                num_layers=config.MODEL.META_ADAPTER.NUM_LAYERS,
+                num_heads=config.MODEL.META_ADAPTER.NUM_HEADS,
+                mlp_ratio=config.MODEL.META_ADAPTER.MLP_RATIO,
+                dropout=config.MODEL.META_ADAPTER.DROPOUT,
+                use_self_attn=config.MODEL.META_ADAPTER.USE_SELF_ATTN,
+            )
+            if self.num_queries > 0:
+                self.query_tokens = nn.Parameter(torch.zeros(1, self.num_queries, self.embed_dim))
+            else:
+                self.register_parameter("query_tokens", None)
         else:
-            self.query_tokens = None
+            self.meta_encoder = None
+            self.meta_adapter = None
+            self.register_parameter("query_tokens", None)
 
         self.use_foreground = bool(config.MODEL.FOREGROUNDNESS.ENABLED)
-        self.foreground_head = ForegroundnessHead(
-            embed_dim=self.embed_dim,
-            hidden_dim=config.MODEL.FOREGROUNDNESS.HIDDEN_DIM,
-            dropout=config.MODEL.FOREGROUNDNESS.DROPOUT,
-        )
+        if self.use_foreground:
+            self.foreground_head = ForegroundnessHead(
+                embed_dim=self.embed_dim,
+                hidden_dim=config.MODEL.FOREGROUNDNESS.HIDDEN_DIM,
+                dropout=config.MODEL.FOREGROUNDNESS.DROPOUT,
+            )
+        else:
+            self.foreground_head = None
 
         self.use_mil = bool(config.MODEL.MIL.ENABLED)
-        self.mil_pool = MILPooling(
-            embed_dim=self.embed_dim,
-            mode=config.MODEL.MIL.POOLING,
-            temperature=config.MODEL.MIL.TEMPERATURE,
-            attention_hidden_dim=config.MODEL.MIL.ATTENTION_HIDDEN_DIM,
-        )
+        if self.use_mil:
+            self.mil_pool = MILPooling(
+                embed_dim=self.embed_dim,
+                mode=config.MODEL.MIL.POOLING,
+                temperature=config.MODEL.MIL.TEMPERATURE,
+                attention_hidden_dim=config.MODEL.MIL.ATTENTION_HIDDEN_DIM,
+            )
+        else:
+            self.mil_pool = None
 
         num_classes = kwargs.get("num_classes")
         task_keys = config.DATA.TASK_KEYS_H5
@@ -193,7 +217,7 @@ class DinoV3MultiHead(BaseModel):
         cls, patch_tokens, grid_size = self.backbone(images)
 
         fg_logits = None
-        if self.use_foreground:
+        if self.use_foreground and self.foreground_head is not None:
             fg_logits = self.foreground_head(patch_tokens)
 
         cls_pooled = cls.squeeze(1)
@@ -222,7 +246,7 @@ class DinoV3MultiHead(BaseModel):
             else:
                 pooled = blend_alpha * masked_pooled + (1.0 - blend_alpha) * cls_pooled
 
-        if self.use_meta_adapter and meta is not None:
+        if self.use_meta_adapter and self.meta_encoder is not None and self.meta_adapter is not None and meta is not None:
             meta_tokens = self.meta_encoder(meta, meta_validity_mask)
             query_list = [pooled.unsqueeze(1)]
             if self.query_tokens is not None:
@@ -297,7 +321,7 @@ class DinoV3MultiHead(BaseModel):
                     )
             pooled, fg_logits = self._forward_single(flat, meta_flat, meta_mask_flat, mask_flat)
             view_tokens = pooled.view(bsz, views, -1)
-            if self.use_mil:
+            if self.use_mil and self.mil_pool is not None:
                 bag_token = self.mil_pool(view_tokens, view_mask=view_mask)
             else:
                 bag_token = self._masked_mean_views(view_tokens, view_mask=view_mask)

--- a/linnaeus/utils/config_utils.py
+++ b/linnaeus/utils/config_utils.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Any
 
 import yaml
 from yacs.config import CfgNode as CN
@@ -119,6 +120,20 @@ def save_config(cfg: CN, save_path: str):
             sort_keys=False,
             allow_unicode=True,
             width=1000,  # Prevent line wrapping
+        )
+
+
+def save_yaml_payload(payload: dict[str, Any], save_path: str) -> None:
+    """Persist a plain YAML payload with the same formatting used for configs."""
+
+    with open(save_path, "w", encoding="utf-8") as f:
+        yaml.dump(
+            payload,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            width=1000,
         )
 
 

--- a/linnaeus/utils/runtime_contract_checks.py
+++ b/linnaeus/utils/runtime_contract_checks.py
@@ -209,6 +209,87 @@ def _check_dinov3_stub_backbone(config: CN, *, policy: RuntimeContractPolicy) ->
     ]
 
 
+def _build_dinov3_optional_module_probe_model(config: CN):
+    from linnaeus.models.dinov3_vnext import DinoV3MultiHead
+
+    probe_cfg = config.clone()
+    probe_cfg.defrost()
+    probe_cfg.MODEL.DINOV3.USE_STUB = True
+    if not list(getattr(probe_cfg.DATA, "TASK_KEYS_H5", [])):
+        probe_cfg.DATA.TASK_KEYS_H5 = ["taxa_L10"]
+    probe_cfg.MODEL.CLASSIFICATION.HEADS = CN(new_allowed=True)
+    for task_key in probe_cfg.DATA.TASK_KEYS_H5:
+        probe_cfg.MODEL.CLASSIFICATION.HEADS[task_key] = {"TYPE": "Linear"}
+    probe_cfg.freeze()
+
+    num_classes = {task_key: 2 for task_key in probe_cfg.DATA.TASK_KEYS_H5}
+    return DinoV3MultiHead(probe_cfg, num_classes=num_classes, taxonomy_tree=None)
+
+
+def _check_dinov3_disabled_optional_modules_are_absent(
+    config: CN, *, policy: RuntimeContractPolicy
+) -> list[RuntimeContractFinding]:
+    # This is intentionally a narrow structural check. It only verifies that
+    # config-disabled optional modules are absent from the trainable set. It
+    # does not prove that config-enabled optional modules are exercised on
+    # every runtime path.
+    model_type = str(getattr(config.MODEL, "TYPE", ""))
+    if model_type != "DINOv3MultiHead":
+        return []
+
+    if bool(getattr(config.DISTRIBUTED.DDP, "find_unused_parameters", False)):
+        return []
+
+    from linnaeus.models.dinov3_vnext import get_disabled_optional_module_state_stems
+
+    disabled_stems = get_disabled_optional_module_state_stems(config)
+    if not disabled_stems:
+        return []
+
+    try:
+        model = _build_dinov3_optional_module_probe_model(config)
+    except Exception as exc:
+        return [
+            RuntimeContractFinding(
+                severity=_severity_for(policy),
+                code="DINOV3_OPTIONAL_MODULE_PROBE_FAILED",
+                message=(
+                    "Unable to verify DINOv3 optional-module topology for "
+                    "DISTRIBUTED.DDP.find_unused_parameters=False: "
+                    f"{exc}"
+                ),
+                remediation=(
+                    "Fix the DINOv3 optional-module probe or use "
+                    "DISTRIBUTED.DDP.find_unused_parameters=True until the model topology can be verified."
+                ),
+            )
+        ]
+
+    leaking = [
+        name
+        for name, param in model.named_parameters()
+        if param.requires_grad and any(name == stem or name.startswith(f"{stem}.") for stem in disabled_stems)
+    ]
+    if not leaking:
+        return []
+
+    return [
+        RuntimeContractFinding(
+            severity=_severity_for(policy),
+            code="DINOV3_DISABLED_OPTIONAL_MODULES_REMAIN_TRAINABLE",
+            message=(
+                "DISTRIBUTED.DDP.find_unused_parameters=False is unsafe for the current DINOv3 config: "
+                "disabled optional modules still expose trainable parameters "
+                f"({', '.join(leaking)})."
+            ),
+            remediation=(
+                "Structurally gate disabled optional modules out of the model, or keep "
+                "DISTRIBUTED.DDP.find_unused_parameters=True for this run."
+            ),
+        )
+    ]
+
+
 def _check_warmup_exceeds_training(config: CN, *, policy: RuntimeContractPolicy) -> list[RuntimeContractFinding]:
     """Warn when warmup epochs exceed total training epochs."""
     warmup_epochs = float(getattr(config.LR_SCHEDULER, "WARMUP_EPOCHS", 0))
@@ -388,6 +469,7 @@ def collect_runtime_contract_findings(
     findings: list[RuntimeContractFinding] = []
     findings.extend(_check_mask_pooling_bbox_runtime(config, policy=normalized_policy))
     findings.extend(_check_dinov3_stub_backbone(config, policy=normalized_policy))
+    findings.extend(_check_dinov3_disabled_optional_modules_are_absent(config, policy=normalized_policy))
     findings.extend(_check_warmup_exceeds_training(config, policy=normalized_policy))
     findings.extend(_check_taxonomy_smoothing_loss_coupling(config, policy=normalized_policy))
     findings.extend(_check_deprecated_key_aliases(config, policy=normalized_policy))

--- a/tests/test_dinov3_vnext_components.py
+++ b/tests/test_dinov3_vnext_components.py
@@ -5,7 +5,20 @@ from linnaeus.config import get_config
 from linnaeus.models.blocks.mask_pooling import mask_weighted_pool
 from linnaeus.models.blocks.query_token_adapter import MetaTokenEncoder
 from linnaeus.models.blocks.mil_pooling import MILPooling
-from linnaeus.models.dinov3_vnext import DinoV3MultiHead
+from linnaeus.models.dinov3_vnext import DinoV3MultiHead, get_disabled_optional_module_state_stems
+
+
+def _make_stub_dinov3_cfg() -> CN:
+    cfg = get_config()
+    cfg.MODEL.TYPE = "DINOv3MultiHead"
+    cfg.MODEL.IN_CHANS = 3
+    cfg.MODEL.DINOV3.USE_STUB = True
+    cfg.MODEL.DINOV3.EMBED_DIM = 32
+    cfg.MODEL.DINOV3.PATCH_SIZE = 4
+    cfg.DATA.TASK_KEYS_H5 = ["taxa_L10"]
+    cfg.MODEL.CLASSIFICATION.HEADS = CN(new_allowed=True)
+    cfg.MODEL.CLASSIFICATION.HEADS["taxa_L10"] = {"TYPE": "Linear"}
+    return cfg
 
 
 def test_mask_weighted_pool_simple():
@@ -205,3 +218,50 @@ def test_detach_pred_w_stops_taxonomy_grads_to_foreground_head():
     out_attached.sum().backward()
     attached_grads = [p.grad for p in model_attached.foreground_head.parameters() if p.requires_grad]
     assert any(g is not None and g.abs().sum().item() > 0 for g in attached_grads)
+
+
+def test_disabled_optional_modules_are_absent_from_trainable_set():
+    cfg = _make_stub_dinov3_cfg()
+    cfg.MODEL.META_ADAPTER.ENABLED = False
+    cfg.MODEL.FOREGROUNDNESS.ENABLED = False
+    cfg.MODEL.MIL.ENABLED = False
+
+    model = DinoV3MultiHead(cfg, num_classes={"taxa_L10": 5}, taxonomy_tree=None)
+
+    assert model.meta_encoder is None
+    assert model.meta_adapter is None
+    assert model.query_tokens is None
+    assert model.foreground_head is None
+    assert model.mil_pool is None
+
+    disabled_stems = get_disabled_optional_module_state_stems(cfg)
+    trainable_names = [name for name, param in model.named_parameters() if param.requires_grad]
+    leaking = [name for name in trainable_names if any(name == stem or name.startswith(f"{stem}.") for stem in disabled_stems)]
+    assert leaking == []
+
+
+def test_enabled_optional_modules_are_constructed_when_requested():
+    cfg = _make_stub_dinov3_cfg()
+    cfg.MODEL.META_ADAPTER.ENABLED = True
+    cfg.MODEL.META_ADAPTER.NUM_QUERIES = 2
+    cfg.MODEL.FOREGROUNDNESS.ENABLED = True
+    cfg.MODEL.FOREGROUNDNESS.HIDDEN_DIM = 16
+    cfg.MODEL.MIL.ENABLED = True
+
+    model = DinoV3MultiHead(cfg, num_classes={"taxa_L10": 5}, taxonomy_tree=None)
+
+    assert model.meta_encoder is not None
+    assert model.meta_adapter is not None
+    assert model.query_tokens is not None
+    assert model.foreground_head is not None
+    assert model.mil_pool is not None
+
+
+def test_zero_query_meta_adapter_marks_query_tokens_as_disabled_for_checkpoint_cleanup():
+    cfg = _make_stub_dinov3_cfg()
+    cfg.MODEL.META_ADAPTER.ENABLED = True
+    cfg.MODEL.META_ADAPTER.NUM_QUERIES = 0
+
+    disabled_stems = get_disabled_optional_module_state_stems(cfg)
+
+    assert "query_tokens" in disabled_stems


### PR DESCRIPTION
## Summary
Sync the current follow-up drift from `linnaeus-dev` into the existing audited public groups.

This batch updates:
- `docs/advanced_topics/hierarchical_approaches.md`
- `linnaeus/config.py`
- `linnaeus/models/dinov3_vnext.py`
- `linnaeus/utils/config_utils.py`
- `linnaeus/utils/runtime_contract_checks.py`
- `tests/test_dinov3_vnext_components.py`

## Verification
- `uv sync --extra dev --extra cpu`
- `uv run pytest tests/test_dinov3_vnext_components.py tests/test_inference_bundle_contract.py tests/test_runtime_core.py -q`
- `uv run python tools/quality_gate.py`
- `git diff --check origin/main...HEAD`

## Notes
This is the public-side half of the parity follow-up after refreshing the integration clones on 2026-04-10. The paired private classification PR should merge after this public batch lands.
