### PR TITLE
POL-1374 remove root CLI advertisement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ promotion flow, and cutover guardrails, see
 ```bash
 uv venv .venv
 uv sync --extra dev --extra cpu
-uv run linnaeus --help
+uv run python -c "import linnaeus; print(linnaeus.__version__)"
+uv run linnaeus-prof --help
 uv run mkdocs build --strict
 ```
 
@@ -53,8 +54,7 @@ For the repo gate that mirrors the core CI baseline, run:
 bash tools/ci/run_core_baseline_gate.sh
 ```
 
-See [docs/dev/05_quality_gates.md](docs/dev/05_quality_gates.md) for scope and
-failure triage.
+See [docs/ci.md](docs/ci.md) for CI scope and failure triage.
 
 ## What This Repo Covers
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -54,11 +54,10 @@ For source training, the current entrypoint is:
 uv run python -m linnaeus.main --cfg path/to/experiment.yaml
 ```
 
-Use the config helpers before launching long runs:
+For public source checkouts, inspect the training entrypoint directly:
 
 ```bash
-uv run linnaeus config render --cfg path/to/experiment.yaml --dry-run --format yaml
-uv run linnaeus config validate --cfg path/to/experiment.yaml --dry-run
+uv run python -m linnaeus.main --help
 ```
 
 See [Training Overview](training/overview.md) for the current source-training

--- a/docs/current_state.md
+++ b/docs/current_state.md
@@ -36,9 +36,10 @@ shared DINOv3 vNext workstream.
 These are the surfaces you can rely on today:
 
 - source training entrypoint: `uv run python -m linnaeus.main --cfg ...`
-- config preflight: `uv run linnaeus config render|validate|explain ...`
-- profiling and experiment tooling: `uv run linnaeus prof ...` and
-  `uv run linnaeus run ...`
+- profiling analysis: `uv run linnaeus-prof ...`
+- profiling trial orchestration: `uv run linnaeus-prof-run ...`
+- config preflight for private operator launches lives with the corresponding
+  private trial manifests and runtime workflows
 - inference contract: bundle-first loading through
   `LinnaeusInferenceHandler.load_from_artifacts(...)`
 - result semantics: `typus`-backed hierarchical outputs

--- a/docs/dev/uv.md
+++ b/docs/dev/uv.md
@@ -3,7 +3,7 @@ title: "UV Local Dev (Golden Path)"
 summary: "Repeatable uv-based CPU and CUDA setup for Linnaeus without Docker."
 tags: [docs, dev, uv]
 date: 2026-01-15
-lastmod: 2026-05-06
+lastmod: 2026-05-11
 x:
   project: linnaeus
   doc_type: docs_page
@@ -49,7 +49,7 @@ bash tools/ci/run_core_baseline_gate.sh
 ```
 
 That command performs the locked sync plus the current scoped lint, test, and type checks. See
-[05_quality_gates.md](./05_quality_gates.md) for the preserved target set and failure triage.
+[CI & Docker Guide](../ci.md) for the preserved target set and failure triage.
 
 ## CUDA (Linux + GPU, e.g., blade)
 

--- a/docs/evaluation/overview.md
+++ b/docs/evaluation/overview.md
@@ -19,7 +19,7 @@ detail:
     final-summary metrics, and interpretation guidance
 *   [Metrics and Logging](../dev/03_metrics_and_logging.md): canonical
     observability naming and payload structure
-*   [Quality Gates](../dev/05_quality_gates.md): broader repo verification
+*   [CI & Docker Guide](../ci.md): broader repo verification
     posture
 *   [Prof Validate](../profiling/prof-validate.md): validation-only preflight
     surface for profiling/operator workflows
@@ -55,5 +55,5 @@ The validation-only profiling validator currently rejects these settings:
 *   `FINAL_EPOCH.EXHAUSTIVE_PARTIAL_META_VALIDATION=True`
 
 That limitation matters for operator workflows that rely on
-`linnaeus config validate` or the profiling validator before launching
+private-runtime config validation or the profiling validator before launching
 validation-only runs.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -26,14 +26,15 @@ These commands tell you quickly whether the repo and entrypoints are in working
 order:
 
 ```bash
-uv run linnaeus --help
-uv run linnaeus config --help
-uv run linnaeus prof --help
+uv run python -c "import linnaeus; print(linnaeus.__version__)"
+uv run python -m linnaeus.main --help
+uv run linnaeus-prof --help
+uv run linnaeus-prof-run --help
 uv run mkdocs build --strict
 ```
 
 If you are working on code changes rather than docs only, use the relevant
-quality gate from [docs/dev/05_quality_gates.md](dev/05_quality_gates.md).
+quality gate from [CI & Docker Guide](ci.md).
 
 ## Know What Is Current
 
@@ -54,20 +55,18 @@ replacing YACS all at once.
 
 ## Learn the Command Surfaces
 
-The main entrypoints are:
+The public package does not expose a root `linnaeus` CLI. Use the source
+training module and the profiling entrypoints directly:
 
 ```bash
-uv run linnaeus --help
-uv run linnaeus config render --help
-uv run linnaeus config validate --help
-uv run linnaeus config explain --help
-uv run linnaeus prof --help
-uv run linnaeus run --help
+uv run python -m linnaeus.main --help
+uv run linnaeus-prof --help
+uv run linnaeus-prof-run --help
 ```
 
-Use `linnaeus config render|validate|explain` before launching long runs. That
-surface exists specifically so you do not have to guess how the config stack
-resolved.
+The training entrypoint consumes the resolved YACS config at launch time. For
+long operator runs, use the private-runtime validation and profiling surfaces
+that correspond to your trial manifests.
 
 ## Next Steps
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,8 +1,8 @@
 # Installation
 
 For most readers, the right way to use this repo is still a local source
-checkout with `uv`. That is the path the docs, CLI checks, and current training
-surface are written around.
+checkout with `uv`. That is the path the docs, import checks, profiling CLIs,
+and current training surface are written around.
 
 ## Requirements
 
@@ -53,11 +53,12 @@ uv run python -c "import flash_attn; print('flash_attn ok')"
 
 ## Verify The Checkout
 
-Use the current CLI surfaces for a fast sanity check:
+Use the current public surfaces for a fast sanity check:
 
 ```bash
-uv run linnaeus --help
-uv run linnaeus config --help
+uv run python -c "import linnaeus; print(linnaeus.__version__)"
+uv run python -m linnaeus.main --help
+uv run linnaeus-prof --help
 uv run mkdocs build --strict
 ```
 

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -34,7 +34,7 @@ For profiling trials shorter than one epoch:
 Example:
 ```bash
 # Example shape only; fill in your own manifest/output paths.
-uv run linnaeus run --trial-params-file trials.jsonl --output-dir results --timeout 120
+uv run linnaeus-prof-run --trial-params-file trials.jsonl --output-dir results --timeout 120
 ```
 
 **Note**: This limitation affects both debug and production early exit mechanisms. Mid-epoch exit support requires refactoring the training loop architecture.
@@ -44,7 +44,7 @@ uv run linnaeus run --trial-params-file trials.jsonl --output-dir results --time
 ## Concurrent Profiling (Experimental)
 
 **Issue**: Running profiling trials concurrently (for example
-`uv run linnaeus run --max-concurrent 2`) can be sensitive to Docker Compose
+`uv run linnaeus-prof-run --max-concurrent 2`) can be sensitive to Docker Compose
 template details and may fail if templates introduce cross-trial collisions.
 
 **Common footguns**:

--- a/docs/models/model_system_overview.md
+++ b/docs/models/model_system_overview.md
@@ -67,8 +67,9 @@ The model system sits inside a broader config transition:
 
 - YACS still owns runtime config resolution today
 - `resolve_config()` is the canonical merge path
-- `linnaeus config render|validate|explain` exists so operators can inspect the
-  final resolved shape before launching a run
+- public source checkouts launch through `python -m linnaeus.main`; private
+  operator workflows own the preflight path for inspecting the final resolved
+  shape before launching a run
 - typed/Pydantic-backed validation is being layered in incrementally, not
   swapped in one shot
 
@@ -84,7 +85,7 @@ If you are adding a new model family:
 2. register it with the model factory
 3. add or update the config surface needed to instantiate it
 4. make the training and inference contracts explicit enough that
-   `linnaeus config validate` and bundle export can fail honestly
+   runtime validation and bundle export can fail honestly
 
 If you are only changing output behavior, adding or extending a classification
 head is usually the cleaner seam.

--- a/docs/profiling/README.md
+++ b/docs/profiling/README.md
@@ -16,16 +16,16 @@ public assets alone.
 The current discovery path is:
 
 ```bash
-uv run linnaeus --help
+uv run linnaeus-prof --help
+uv run linnaeus-prof-run --help
 ```
 
 Current mapping:
 
-- `linnaeus run ...` delegates to the trial runner surface
-- `linnaeus prof ...` delegates to the profiler analysis surface
-- `linnaeus config render|validate|validation-plan ...` handles preflight
-  config work without launching a run
-- legacy `linnaeus-prof` and `linnaeus-prof-run` commands still exist
+- `linnaeus-prof ...` provides profiler analysis and reporting
+- `linnaeus-prof-run ...` orchestrates repeated or comparative profiling runs
+- config preflight for private operator launches lives with the corresponding
+  private trial manifests and runtime workflows
 
 ## Public-Safe Quickstart
 
@@ -34,16 +34,15 @@ manifests:
 
 ```bash
 uv sync --extra dev --extra profiling --extra cpu
-uv run linnaeus --help
-uv run linnaeus prof --help
-uv run linnaeus config validate --help
+uv run linnaeus-prof --help
+uv run linnaeus-prof-run --help
 ```
 
 If you already have a profiler output directory, you can analyze it directly:
 
 ```bash
-uv run linnaeus prof summary /path/to/run --output-format md
-uv run linnaeus prof diff /path/to/baseline /path/to/candidate --output-format md
+uv run linnaeus-prof summary /path/to/run --output-format md
+uv run linnaeus-prof diff /path/to/baseline /path/to/candidate --output-format md
 ```
 
 ## What Usually Stays Private
@@ -89,7 +88,7 @@ baseline.
 
 ### Preflight a launch surface
 
-Use `linnaeus config validate` and `prof-validate` before long profiling waves.
+Use the private-runtime config validation path before long profiling waves.
 That catches path, config, and contract failures sooner than a failed Docker
 launch.
 

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -4,8 +4,9 @@
 > The active experimentation line is `DINOv3MultiHead`. Older mFormer config
 > files still exist in the tree but are no longer the main public story.
 
-This page focuses on what matters for training now: how to preflight configs,
-launch runs honestly, and interpret the main decision surfaces.
+This page focuses on what matters for training now: how to launch runs
+honestly, keep config provenance clear, and interpret the main decision
+surfaces.
 
 ## Current Training Loop
 
@@ -17,16 +18,15 @@ uv run python -m linnaeus.main \
   --opts EXPERIMENT.WANDB.ENABLED True
 ```
 
-Before you launch a real run, use the config preflight surface:
+For public source checkouts, inspect the training entrypoint directly:
 
 ```bash
-uv run linnaeus config render --cfg /abs/path/to/experiment.yaml
-uv run linnaeus config validate --cfg /abs/path/to/experiment.yaml
-uv run linnaeus config explain MODEL.TYPE --cfg /abs/path/to/experiment.yaml
+uv run python -m linnaeus.main --help
 ```
 
-That is the right way to inspect the resolved config stack. Do not guess from a
-single YAML file.
+For long operator runs, keep config preflight in the private-runtime workflow
+that owns the corresponding trial manifests and deployment assets. Do not guess
+from a single YAML file.
 
 ## What The Training Stack Covers
 
@@ -57,8 +57,8 @@ Three facts matter here:
    though the active experimentation line has moved to DINOv3.
 
 For DINOv3 runs, operators usually set `MODEL.TYPE: DINOv3MultiHead` and avoid
-inheriting mFormer arch files by accident. Use `linnaeus config render` or
-`linnaeus config explain MODEL.TYPE` to confirm what actually resolved.
+inheriting mFormer arch files by accident. Confirm the resolved config through
+the runtime or private preflight path before launching long jobs.
 
 ## Metrics That Drive Decisions
 
@@ -87,7 +87,7 @@ A lower loss does not rescue a run that regresses PCA.
 
 1. Prepare your dataset and taxonomy surfaces.
 2. Author or adapt an experiment config.
-3. Run `linnaeus config render|validate`.
+3. Confirm the resolved config through the runtime or private preflight path.
 4. Launch with `python -m linnaeus.main`.
 5. Watch PCA, DWPCA, per-rank accuracies, and schedule summaries.
 6. Use profiling or validation-only flows when you need operator-level receipts.

--- a/docs/training/training_custom_model_example.md
+++ b/docs/training/training_custom_model_example.md
@@ -66,19 +66,18 @@ TRAIN:
   EPOCHS: 10
 ```
 
-The point of the example is the contract, not the exact hyperparameters. Use
-the config preflight tools to inspect what your real config resolves to.
+The point of the example is the contract, not the exact hyperparameters.
+Before long operator runs, inspect what your real config resolves to through
+the private-runtime preflight path that owns your trial manifests.
 
-## 3. Render And Validate Before Launch
+## 3. Inspect Before Launch
 
 ```bash
-uv run linnaeus config render --cfg /abs/path/to/my_experiment.yaml
-uv run linnaeus config validate --cfg /abs/path/to/my_experiment.yaml
-uv run linnaeus config explain MODEL.TYPE --cfg /abs/path/to/my_experiment.yaml
+uv run python -m linnaeus.main --help
 ```
 
-If validation fails, fix that first. Do not start training and hope the runtime
-will sort it out.
+If private-runtime validation fails, fix that first. Do not start training and
+hope the runtime will sort it out.
 
 ## 4. Launch Training
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
 ]
 
 [project.scripts]
-linnaeus = "linnaeus.cli:main"
 linnaeus-prof = "linnaeus.profiling.cli:main"
 linnaeus-prof-run = "linnaeus.tools.profiling.run_profiling_trials:main"
 

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import importlib.util
+import tomllib
+from pathlib import Path
+
+
+def test_public_scripts_do_not_advertise_missing_root_cli() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    scripts = pyproject["project"]["scripts"]
+
+    assert "linnaeus" not in scripts
+    assert scripts["linnaeus-prof"] == "linnaeus.profiling.cli:main"
+    assert scripts["linnaeus-prof-run"] == "linnaeus.tools.profiling.run_profiling_trials:main"
+    assert importlib.util.find_spec("linnaeus.cli") is None


### PR DESCRIPTION
## Summary
- remove the nonexistent root `linnaeus` console script from public package metadata
- update public onboarding/training/profiling docs to use `python -m linnaeus.main`, `linnaeus-prof`, and `linnaeus-prof-run` instead of a root CLI
- add a package metadata smoke test that proves the root CLI is not advertised while profiling entrypoints remain

## Verification
- `uv run pytest tests/test_package_metadata.py -q`
- `uv run python - <<'PY' ... PY` metadata/import smoke: `linnaeus advertised: False`, `linnaeus.cli spec: None`
- `uv run linnaeus-prof --help`
- `uv run linnaeus-prof-run --help`
- `uv run --extra dev mkdocs build --strict`
- `uv run --locked --extra dev --extra cpu python tools/quality_gate.py`

## Notes
- Left unrelated untracked `.calyx-runner.lock` untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and getting started guides to reflect new command surfaces (`linnaeus.main`, `linnaeus-prof`, `linnaeus-prof-run`).
  * Refreshed training, profiling, and workflow documentation across all guides.

* **Refactor**
  * Removed root `linnaeus` CLI command; functionality now accessed via module entrypoints and profiling CLI tools.

* **Tests**
  * Added test to validate console script configuration and ensure correct CLI commands are advertised.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/polli-labs/linnaeus/pull/110)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->